### PR TITLE
feat(v0.1.2): settlement-risk badge + pm_quote + pm_disputes_active

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,24 @@ allbets does steps 1-4 in a single tool call.
 
 ## Tools
 
-- **`pm_discover(hypothesis, jurisdiction?)`** — primary tool. Fan out across 3 venues, return what each has on your hypothesis + jurisdiction notes + recommended trade-here URL. Use this first.
-- **`pm_search(query, venues?)`** — raw cross-venue search. Less curated than `pm_discover`.
-- **`pm_list_active(venues?)`** — most active markets per venue, for browsing.
+| Tool | Use for |
+|---|---|
+| `pm_discover(hypothesis, jurisdiction?)` | **Primary.** Fan out across 3 venues, return what each has + jurisdiction notes + recommended trade-here URL. |
+| `pm_quote(market_url_or_id)` | Single-market deep-dive with full **settlement-risk badge** (UMA dispute window, bond, resolution status). Use after `pm_discover` to see the trust shape behind a price. |
+| `pm_disputes_active(limit?)` | List Polymarket markets currently UMA-flagged (proposed-but-not-finalized OR actively disputed). Polymarket flipped >$30M of resolutions in 2025 — agents holding positions need to know. |
+| `pm_search(query, venues?)` | Raw cross-venue search. Less curated than `pm_discover`. |
+| `pm_list_active(venues?)` | Most active markets per venue, for browsing. |
 
 All reads are public-API only. **Trading is intentionally not in scope** — identity, custody, and funding fragmentation across the three venues makes a unified write-API a fool's errand. allbets is the *information* primitive; trade execution stays with the agent's existing per-venue tools.
+
+## Settlement risk
+
+Every quote carries a `settlement_risk: "low" | "moderate" | "high"` badge plus `settlement_risk_reason`. Computed for all venues uniformly. Kalshi (centralized) and Limitless (Pyth-deterministic) are `low` by default — that's a feature, not noise: the agent has confirmation that the settlement model is reliable.
+
+For Polymarket (UMA Optimistic Oracle):
+- **HIGH:** `uma_resolution_statuses` contains `proposed` or `disputed`, OR the dispute window is currently open
+- **MODERATE:** `custom_liveness_seconds > 86400` (>24h dispute window), OR `uma_bond < 500` USDC (under-collateralized vs default), OR resolution `description` is thin (<200 chars; ambiguity proxy)
+- **LOW:** none of the above
 
 ## Normalized schema
 

--- a/src/adapters/kalshi.ts
+++ b/src/adapters/kalshi.ts
@@ -78,6 +78,8 @@ function toNormalized(m: KalshiMarket): NormalizedMarket {
     open_interest_usd: n(m.open_interest_fp),
     ends_at: m.close_time,
     resolution_status: statusToResolution(m.status),
+    settlement_risk: "low",
+    settlement_risk_reason: "kalshi central clearinghouse, no dispute window",
     chain: "centralized",
     collateral_token: "USD",
     restricted_jurisdictions: ["non-US"],

--- a/src/adapters/limitless.ts
+++ b/src/adapters/limitless.ts
@@ -64,6 +64,8 @@ function toNormalized(m: LimitlessMarket): NormalizedMarket {
     open_interest_usd: n(m.openInterest),
     ends_at: m.expirationDate,
     resolution_status: inferResolutionStatus(m),
+    settlement_risk: "low",
+    settlement_risk_reason: "limitless deterministic pyth oracle resolution",
     chain: "base",
     collateral_token: "USDC",
     is_parlay: false,

--- a/src/adapters/polymarket.ts
+++ b/src/adapters/polymarket.ts
@@ -1,5 +1,9 @@
 import type { VenueAdapter } from "./types.js";
-import type { NormalizedMarket, ResolutionStatus } from "../schema.js";
+import type {
+  NormalizedMarket,
+  ResolutionStatus,
+  SettlementRisk,
+} from "../schema.js";
 
 const GAMMA_BASE = "https://gamma-api.polymarket.com";
 
@@ -28,7 +32,10 @@ interface GammaMarket {
   umaResolutionStatus?: string;
   umaResolutionStatuses?: string;
   customLiveness?: string;
+  umaBond?: string;
+  umaReward?: string;
   acceptingOrders?: boolean;
+  acceptingOrdersTimestamp?: string;
 }
 
 function parseJsonArray(s: string | undefined): string[] {
@@ -40,15 +47,95 @@ function parseJsonArray(s: string | undefined): string[] {
   }
 }
 
+function parseUmaStatuses(m: GammaMarket): string[] {
+  if (m.umaResolutionStatuses) {
+    try {
+      const arr = JSON.parse(m.umaResolutionStatuses);
+      if (Array.isArray(arr)) return arr.map(String).map((s) => s.toLowerCase());
+    } catch {
+      // fall through
+    }
+  }
+  return m.umaResolutionStatus ? [m.umaResolutionStatus.toLowerCase()] : [];
+}
+
+function n(v: string | undefined): number | undefined {
+  if (v === undefined || v === null) return undefined;
+  const x = Number(v);
+  return Number.isFinite(x) ? x : undefined;
+}
+
 function inferResolutionStatus(m: GammaMarket): ResolutionStatus {
+  const statuses = parseUmaStatuses(m);
+  if (statuses.some((s) => s.includes("dispute"))) return "in_dispute";
   if (m.closed === true) {
-    const status = (m.umaResolutionStatus ?? "").toLowerCase();
-    if (status.includes("dispute")) return "in_dispute";
-    if (status === "resolved" || status === "settled") return "settled";
+    if (statuses.some((s) => s === "resolved" || s === "settled")) return "settled";
     return "closed_pending_resolution";
   }
   if (m.acceptingOrders === false) return "closed_pending_resolution";
   return "open";
+}
+
+function computeDisputeOpenUntil(m: GammaMarket): string | undefined {
+  const statuses = parseUmaStatuses(m);
+  const flagged = statuses.some((s) => s.includes("propose") || s.includes("dispute"));
+  if (!flagged) return undefined;
+  const liveness = n(m.customLiveness);
+  const acceptingTs = n(m.acceptingOrdersTimestamp);
+  if (!liveness || !acceptingTs) return undefined;
+  const ms = acceptingTs * 1000 + liveness * 1000;
+  return new Date(ms).toISOString();
+}
+
+interface SettlementJudgement {
+  risk: SettlementRisk;
+  reason: string;
+}
+
+function computeSettlementRisk(
+  m: GammaMarket,
+  statuses: string[],
+  disputeOpenUntil: string | undefined,
+): SettlementJudgement {
+  const liveness = n(m.customLiveness);
+  const bond = n(m.umaBond);
+  const description = m.description ?? "";
+
+  // HIGH: explicit dispute / proposed status, OR active dispute window not yet closed
+  if (statuses.some((s) => s.includes("dispute"))) {
+    return { risk: "high", reason: "uma_resolution_statuses contains 'disputed'" };
+  }
+  if (statuses.some((s) => s.includes("propose") || s.includes("pending"))) {
+    return { risk: "high", reason: "uma_resolution_statuses contains 'proposed' (not yet finalized)" };
+  }
+  if (disputeOpenUntil) {
+    const stillOpen = Date.parse(disputeOpenUntil) > Date.now();
+    if (stillOpen) {
+      return { risk: "high", reason: `uma dispute window open until ${disputeOpenUntil}` };
+    }
+  }
+
+  // MODERATE: long dispute window, under-bonded, or thin resolution rules
+  if (liveness !== undefined && liveness > 86400) {
+    return {
+      risk: "moderate",
+      reason: `uma dispute window > 24h (${Math.round(liveness / 3600)}h)`,
+    };
+  }
+  if (bond !== undefined && bond > 0 && bond < 500) {
+    return {
+      risk: "moderate",
+      reason: `uma bond under-collateralized (${bond} USDC < 500 default)`,
+    };
+  }
+  if (description.length < 200) {
+    return {
+      risk: "moderate",
+      reason: `polymarket resolution description thin (${description.length} chars < 200) — ambiguity risk`,
+    };
+  }
+
+  return { risk: "low", reason: "uma optimistic oracle, no dispute flags, well-bonded" };
 }
 
 function toNormalized(m: GammaMarket): NormalizedMarket {
@@ -56,6 +143,9 @@ function toNormalized(m: GammaMarket): NormalizedMarket {
   const prices = parseJsonArray(m.outcomePrices).map((p) => Number(p));
   const tokenIds = parseJsonArray(m.clobTokenIds);
   const event = m.events?.[0];
+  const statuses = parseUmaStatuses(m);
+  const disputeOpenUntil = computeDisputeOpenUntil(m);
+  const judgement = computeSettlementRisk(m, statuses, disputeOpenUntil);
 
   return {
     venue: "polymarket",
@@ -73,7 +163,13 @@ function toNormalized(m: GammaMarket): NormalizedMarket {
     volume_usd: m.volume ? Number(m.volume) : undefined,
     ends_at: m.endDate,
     resolution_status: inferResolutionStatus(m),
-    dispute_open_until: m.customLiveness,
+    dispute_open_until: disputeOpenUntil,
+    settlement_risk: judgement.risk,
+    settlement_risk_reason: judgement.reason,
+    uma_resolution_statuses: statuses.length > 0 ? statuses : undefined,
+    uma_bond: n(m.umaBond),
+    uma_reward: n(m.umaReward),
+    custom_liveness_seconds: n(m.customLiveness),
     chain: "polygon",
     collateral_token: "USDC.e",
     restricted_jurisdictions: ["US"],
@@ -120,5 +216,31 @@ export class PolymarketAdapter implements VenueAdapter {
     if (!res.ok) throw new Error(`polymarket listActive failed: ${res.status}`);
     const json = (await res.json()) as GammaMarket[];
     return json.slice(0, limit).map(toNormalized);
+  }
+
+  async listDisputed(limit = 20): Promise<NormalizedMarket[]> {
+    const candidates = new Map<string, NormalizedMarket>();
+    const queries = ["dispute", "disputed", "proposed", "pending"];
+    for (const q of queries) {
+      const url = new URL(`${GAMMA_BASE}/markets`);
+      url.searchParams.set("limit", "100");
+      url.searchParams.set("q", q);
+      const res = await fetch(url);
+      if (!res.ok) continue;
+      const json = (await res.json()) as GammaMarket[];
+      for (const raw of json) {
+        const market = toNormalized(raw);
+        if (market.settlement_risk === "high") {
+          candidates.set(market.venue_market_id, market);
+        }
+      }
+    }
+    const list = Array.from(candidates.values());
+    list.sort((a, b) => {
+      const ad = a.dispute_open_until ? Date.parse(a.dispute_open_until) : Infinity;
+      const bd = b.dispute_open_until ? Date.parse(b.dispute_open_until) : Infinity;
+      return ad - bd;
+    });
+    return list.slice(0, limit);
   }
 }

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -5,4 +5,5 @@ export interface VenueAdapter {
   searchMarkets(query: string, limit?: number): Promise<NormalizedMarket[]>;
   getMarket(venueMarketId: string): Promise<NormalizedMarket | null>;
   listActive(limit?: number): Promise<NormalizedMarket[]>;
+  listDisputed?(limit?: number): Promise<NormalizedMarket[]>;
 }

--- a/src/landing.ts
+++ b/src/landing.ts
@@ -418,7 +418,15 @@ export const LANDING_HTML = `<!doctype html>
 
       <div class="feature-row">
         <div class="label">pm_discover</div>
-        <div class="body">Hand it a hypothesis and a jurisdiction. Returns what each venue lists, the depth of liquidity, the resolution model, and a single recommended trade-here URL. The primary tool.</div>
+        <div class="body">Hand it a hypothesis and a jurisdiction. Returns what each venue lists, the depth of liquidity, the resolution model, and a single recommended trade-here URL. The primary entry tool.</div>
+      </div>
+      <div class="feature-row">
+        <div class="label">pm_quote</div>
+        <div class="body">Single-market deep-dive with the <em>settlement-risk badge</em>. Pass a Polymarket / Kalshi / Limitless URL or a <code>venue:id</code> shorthand. Returns the full normalized market plus UMA dispute window, bond, and resolution status. The trust shape behind the price.</div>
+      </div>
+      <div class="feature-row">
+        <div class="label">pm_disputes_active</div>
+        <div class="body">Polymarket markets currently UMA-flagged (proposed-but-not-finalized or actively disputed). Polymarket flipped over $30M of supposedly-final resolutions in 2025. Every other MCP shows the stale number; this one surfaces the risk.</div>
       </div>
       <div class="feature-row">
         <div class="label">pm_search</div>
@@ -429,8 +437,8 @@ export const LANDING_HTML = `<!doctype html>
         <div class="body">Most active markets per venue, ranked by volume. For browsing.</div>
       </div>
       <div class="feature-row">
-        <div class="label">normalized schema</div>
-        <div class="body">Every market comes back in one shape: outcome probabilities, bid/ask, liquidity in USD, resolution status, dispute window for UMA-settled markets, chain, collateral token, restricted jurisdictions, and a tradable outcome ID for downstream execution.</div>
+        <div class="label">settlement risk</div>
+        <div class="body">Every quote carries <code>settlement_risk: low | moderate | high</code> with a human-readable reason. Computed uniformly for all venues. UMA dispute windows, bond size, and resolution-rule thinness all feed in. The agent capability that didn&apos;t exist before.</div>
       </div>
     </section>
 

--- a/src/landing.ts
+++ b/src/landing.ts
@@ -1,0 +1,547 @@
+export const LANDING_HTML = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>allbets — cross-venue prediction-market discovery for AI agents</title>
+  <meta name="description" content="One MCP endpoint. Three real-money prediction-market venues. Tell your agent your hypothesis, allbets tells you what is tradable, where the liquidity is, and what to watch for at settlement." />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+
+  <style>
+    :root {
+      --bg: #0a0d0a;
+      --bg-elevated: #0f1410;
+      --rule: #1c2820;
+      --rule-strong: #2a3a2c;
+      --text: #e8efe5;
+      --text-muted: #7a8478;
+      --text-dim: #4a504a;
+      --accent: #5fff5f;
+      --accent-dim: #2f8a2f;
+      --warn: #ffb55a;
+      --warn-dim: #8a5e2f;
+      --serif: "Instrument Serif", "Iowan Old Style", Palatino, serif;
+      --mono: "Geist Mono", "SF Mono", ui-monospace, monospace;
+    }
+
+    * { box-sizing: border-box; }
+
+    html, body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: var(--mono);
+      font-size: 15px;
+      line-height: 1.6;
+      margin: 0;
+      padding: 0;
+      -webkit-font-smoothing: antialiased;
+      text-rendering: optimizeLegibility;
+    }
+
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      background:
+        radial-gradient(ellipse at top, rgba(95, 255, 95, 0.04), transparent 60%),
+        radial-gradient(ellipse at bottom right, rgba(255, 181, 90, 0.025), transparent 50%);
+      z-index: 0;
+    }
+
+    main {
+      position: relative;
+      z-index: 1;
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 64px 32px 96px;
+    }
+
+    .topbar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-family: var(--mono);
+      font-size: 13px;
+      color: var(--text-muted);
+      letter-spacing: 0.02em;
+      padding-bottom: 80px;
+    }
+
+    .topbar .brand {
+      color: var(--text);
+      font-weight: 600;
+    }
+
+    .topbar .brand::before {
+      content: "▌ ";
+      color: var(--accent);
+    }
+
+    .topbar .status {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .topbar .status::before {
+      content: "";
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--accent);
+      box-shadow: 0 0 8px var(--accent);
+      animation: pulse 2.4s ease-in-out infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.4; }
+    }
+
+    .hero {
+      padding-bottom: 64px;
+    }
+
+    .hero .eyebrow {
+      font-family: var(--mono);
+      font-size: 12px;
+      color: var(--accent);
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      margin-bottom: 20px;
+    }
+
+    .hero h1 {
+      font-family: var(--serif);
+      font-weight: 400;
+      font-size: clamp(40px, 7vw, 64px);
+      line-height: 1.04;
+      letter-spacing: -0.015em;
+      margin: 0 0 24px;
+      color: var(--text);
+    }
+
+    .hero h1 em {
+      font-style: italic;
+      color: var(--accent);
+    }
+
+    .hero h1 .typed {
+      display: inline;
+    }
+
+    .hero h1 .cursor {
+      display: inline-block;
+      width: 0.5ch;
+      background: var(--accent);
+      animation: blink 1s steps(1) infinite;
+      margin-left: 2px;
+      transform: translateY(2px);
+    }
+
+    @keyframes blink {
+      50% { opacity: 0; }
+    }
+
+    .hero p.lede {
+      font-family: var(--serif);
+      font-size: 22px;
+      line-height: 1.45;
+      color: var(--text-muted);
+      max-width: 60ch;
+      margin: 0 0 36px;
+    }
+
+    .hero .cta-row {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 20px;
+      font-family: var(--mono);
+      font-size: 13px;
+      font-weight: 500;
+      letter-spacing: 0.02em;
+      text-decoration: none;
+      border: 1px solid var(--rule-strong);
+      color: var(--text);
+      background: transparent;
+      transition: border-color 0.15s, color 0.15s, background 0.15s;
+    }
+    .btn:hover { border-color: var(--accent); color: var(--accent); }
+    .btn.primary { border-color: var(--accent); color: var(--accent); }
+    .btn.primary:hover { background: var(--accent); color: var(--bg); }
+    .btn::after { content: "→"; }
+
+    hr.rule {
+      border: 0;
+      border-top: 1px solid var(--rule);
+      margin: 64px 0;
+    }
+
+    section h2 {
+      font-family: var(--serif);
+      font-style: italic;
+      font-weight: 400;
+      font-size: 32px;
+      line-height: 1.2;
+      letter-spacing: -0.01em;
+      margin: 0 0 24px;
+      color: var(--text);
+    }
+
+    section h2 .num {
+      font-family: var(--mono);
+      font-style: normal;
+      font-size: 12px;
+      color: var(--accent);
+      letter-spacing: 0.2em;
+      vertical-align: top;
+      margin-right: 12px;
+    }
+
+    section p {
+      max-width: 60ch;
+      color: var(--text);
+      margin: 0 0 16px;
+    }
+
+    section p.muted { color: var(--text-muted); }
+
+    .venue-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1px;
+      background: var(--rule);
+      border: 1px solid var(--rule);
+      margin: 32px 0;
+    }
+    @media (max-width: 640px) {
+      .venue-grid { grid-template-columns: 1fr; }
+    }
+
+    .venue {
+      background: var(--bg-elevated);
+      padding: 24px 20px;
+    }
+
+    .venue .name {
+      font-family: var(--serif);
+      font-style: italic;
+      font-size: 24px;
+      color: var(--text);
+      margin-bottom: 8px;
+    }
+
+    .venue .vol {
+      font-family: var(--mono);
+      font-size: 22px;
+      font-weight: 600;
+      color: var(--accent);
+      margin-bottom: 4px;
+    }
+
+    .venue .meta {
+      font-family: var(--mono);
+      font-size: 12px;
+      color: var(--text-muted);
+      line-height: 1.6;
+    }
+
+    .venue .tag {
+      display: inline-block;
+      font-size: 10px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      padding: 2px 6px;
+      border: 1px solid var(--rule-strong);
+      color: var(--text-muted);
+      margin-top: 12px;
+    }
+    .venue .tag.us { color: var(--warn); border-color: var(--warn-dim); }
+    .venue .tag.geo { color: var(--warn); border-color: var(--warn-dim); }
+    .venue .tag.crypto { color: var(--accent); border-color: var(--accent-dim); }
+
+    .feature-row {
+      display: grid;
+      grid-template-columns: max-content 1fr;
+      gap: 8px 24px;
+      align-items: baseline;
+      margin: 8px 0;
+      padding-bottom: 12px;
+      border-bottom: 1px dashed var(--rule);
+    }
+    .feature-row:last-child { border-bottom: 0; }
+
+    .feature-row .label {
+      font-family: var(--mono);
+      font-size: 11px;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: var(--accent);
+      white-space: nowrap;
+    }
+
+    .feature-row .body { color: var(--text); }
+
+    pre.code {
+      background: var(--bg-elevated);
+      border: 1px solid var(--rule);
+      border-left: 2px solid var(--accent);
+      padding: 18px 20px;
+      margin: 20px 0;
+      overflow-x: auto;
+      font-family: var(--mono);
+      font-size: 13px;
+      line-height: 1.65;
+      color: var(--text);
+    }
+    pre.code .c { color: var(--text-muted); }
+    pre.code .k { color: var(--accent); }
+    pre.code .s { color: var(--warn); }
+
+    .badge-demo {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 4px 10px;
+      font-family: var(--mono);
+      font-size: 11px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      border: 1px solid var(--warn-dim);
+      color: var(--warn);
+      background: rgba(255, 181, 90, 0.06);
+    }
+    .badge-demo::before {
+      content: "▲";
+      font-size: 10px;
+    }
+
+    footer {
+      margin-top: 96px;
+      padding-top: 32px;
+      border-top: 1px solid var(--rule);
+      font-family: var(--mono);
+      font-size: 12px;
+      color: var(--text-muted);
+      display: flex;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 16px;
+    }
+    footer a { color: var(--text-muted); text-decoration: none; border-bottom: 1px dotted var(--text-dim); }
+    footer a:hover { color: var(--accent); border-color: var(--accent); }
+
+    .reveal { opacity: 0; transform: translateY(8px); animation: reveal 0.6s ease forwards; }
+    @keyframes reveal {
+      to { opacity: 1; transform: translateY(0); }
+    }
+    .d1 { animation-delay: 0.4s; }
+    .d2 { animation-delay: 0.6s; }
+    .d3 { animation-delay: 0.8s; }
+    .d4 { animation-delay: 1.0s; }
+  </style>
+</head>
+<body>
+  <main>
+    <div class="topbar">
+      <div class="brand">allbets</div>
+      <div class="status">live · cf workers · v0.1.1</div>
+    </div>
+
+    <section class="hero">
+      <div class="eyebrow reveal">Built at Agents Day Lisbon · 2026-05-01</div>
+      <h1><span class="typed" id="typed"></span><span class="cursor">&nbsp;</span></h1>
+      <p class="lede reveal d1">
+        One <em>MCP endpoint</em>. Three real-money prediction-market venues. Tell your agent your hypothesis &mdash; allbets tells you what is tradable, where the liquidity is, and what to watch for at settlement.
+      </p>
+      <div class="cta-row reveal d2">
+        <a class="btn primary" href="#try">Try the endpoint</a>
+        <a class="btn" href="https://github.com/scrollinondubs/allbets" target="_blank" rel="noopener">View on GitHub</a>
+      </div>
+    </section>
+
+    <hr class="rule" />
+
+    <section>
+      <h2><span class="num">01</span>The problem</h2>
+      <p>
+        Prediction markets crossed <strong>$27B in monthly volume</strong> in January 2026 &mdash; roughly five times the prior year. Three venues now dominate real-money flow: Kalshi, Polymarket, Limitless. They share almost nothing. Different identities. Different settlement models. Different jurisdictions. Different collateral tokens.
+      </p>
+      <p>
+        An AI agent that wants to bet on a hypothesis has to know which venues even list the question, which it can legally trade on, where the liquidity actually is, and how badly settlement could surprise it. Today that is four separate API surfaces and a research afternoon.
+      </p>
+
+      <div class="venue-grid">
+        <div class="venue">
+          <div class="name">Kalshi</div>
+          <div class="vol">$9.5B</div>
+          <div class="meta">Jan 2026 volume<br />CFTC-regulated · USD<br />RSA-PSS auth · KYC required</div>
+          <span class="tag us">US-only</span>
+        </div>
+        <div class="venue">
+          <div class="name">Polymarket</div>
+          <div class="vol">$3.3B</div>
+          <div class="meta">Jan 2026 volume<br />Polygon CLOB · USDC.e<br />EIP-712 wallet auth</div>
+          <span class="tag geo">Geo-blocked from US</span>
+        </div>
+        <div class="venue">
+          <div class="name">Limitless</div>
+          <div class="vol">$789M</div>
+          <div class="meta">Jan 2026 volume<br />Base · USDC<br />Wallet + HMAC auth</div>
+          <span class="tag crypto">Crypto-native</span>
+        </div>
+      </div>
+
+      <p class="muted">
+        Capital sits on three different chains. None of it is fungible. A US agent cannot trade Polymarket-international. A non-US agent cannot trade Kalshi. Most of these facts are not visible from any single venue&apos;s docs.
+      </p>
+    </section>
+
+    <hr class="rule" />
+
+    <section>
+      <h2><span class="num">02</span>What allbets does</h2>
+      <p>
+        One MCP endpoint over <strong>Streamable HTTP</strong>. Three tools. Read-only. Public APIs only. No keys at runtime.
+      </p>
+
+      <div class="feature-row">
+        <div class="label">pm_discover</div>
+        <div class="body">Hand it a hypothesis and a jurisdiction. Returns what each venue lists, the depth of liquidity, the resolution model, and a single recommended trade-here URL. The primary tool.</div>
+      </div>
+      <div class="feature-row">
+        <div class="label">pm_search</div>
+        <div class="body">Raw cross-venue search. Less curated. Useful when you want the full set rather than the best match.</div>
+      </div>
+      <div class="feature-row">
+        <div class="label">pm_list_active</div>
+        <div class="body">Most active markets per venue, ranked by volume. For browsing.</div>
+      </div>
+      <div class="feature-row">
+        <div class="label">normalized schema</div>
+        <div class="body">Every market comes back in one shape: outcome probabilities, bid/ask, liquidity in USD, resolution status, dispute window for UMA-settled markets, chain, collateral token, restricted jurisdictions, and a tradable outcome ID for downstream execution.</div>
+      </div>
+    </section>
+
+    <hr class="rule" />
+
+    <section>
+      <h2><span class="num">03</span>What it deliberately is not</h2>
+      <p>
+        allbets is the <em>information</em> primitive. Not the execution primitive.
+      </p>
+      <p class="muted">
+        Trading across these venues is hard for reasons that have nothing to do with API plumbing. Three incompatible auth models. KYC versus wallet. Capital fragmentation across chains and clearinghouses. Settlement windows that range from seconds (Kalshi) to days (Polymarket UMA disputes). MCP is the wrong shape for orchestrating that.
+      </p>
+      <p class="muted">
+        Trade execution stays with the agent&apos;s existing per-venue tools: Polymarket Agents, Olas Polystrat, shaanmajid&apos;s prediction-mcp. allbets answers <em>where</em>. They answer <em>place</em>.
+      </p>
+    </section>
+
+    <hr class="rule" />
+
+    <section id="try">
+      <h2><span class="num">04</span>Try it</h2>
+      <p>The MCP endpoint is live now at <strong>https://allbets.dev/mcp</strong>. JSON-RPC 2.0 over HTTP POST.</p>
+
+      <pre class="code"><span class="c"># list tools</span>
+<span class="k">curl</span> -X POST https://allbets.dev/mcp \\
+  -H <span class="s">"Content-Type: application/json"</span> \\
+  -d <span class="s">'{"jsonrpc":"2.0","id":1,"method":"tools/list"}'</span>
+
+<span class="c"># discover what is tradable on a hypothesis</span>
+<span class="k">curl</span> -X POST https://allbets.dev/mcp \\
+  -H <span class="s">"Content-Type: application/json"</span> \\
+  -d <span class="s">'{
+    "jsonrpc":"2.0","id":1,"method":"tools/call",
+    "params":{
+      "name":"pm_discover",
+      "arguments":{
+        "hypothesis":"Powell cuts rates in June",
+        "jurisdiction":"non_us"
+      }
+    }
+  }'</span></pre>
+
+      <p class="muted" style="margin-top: 24px;">
+        <span class="badge-demo">Live</span>
+        &nbsp;Hitting public Polymarket, Kalshi, and Limitless APIs in parallel from the Cloudflare edge. No auth. ~300ms typical roundtrip from Lisbon.
+      </p>
+    </section>
+
+    <hr class="rule" />
+
+    <section>
+      <h2><span class="num">05</span>Connect from Claude Desktop</h2>
+      <p>Add to <code>~/Library/Application Support/Claude/claude_desktop_config.json</code>:</p>
+
+      <pre class="code">{
+  <span class="k">"mcpServers"</span>: {
+    <span class="k">"allbets"</span>: {
+      <span class="k">"transport"</span>: {
+        <span class="k">"type"</span>: <span class="s">"streamable-http"</span>,
+        <span class="k">"url"</span>: <span class="s">"https://allbets.dev/mcp"</span>
+      }
+    }
+  }
+}</pre>
+
+      <p class="muted">Restart Claude Desktop. Ask: &ldquo;What does the market think about a Fed rate cut in June?&rdquo;</p>
+    </section>
+
+    <hr class="rule" />
+
+    <section>
+      <h2><span class="num">06</span>The code</h2>
+      <p>
+        Open-source under MIT at <a href="https://github.com/scrollinondubs/allbets" style="color: var(--accent); text-decoration: none; border-bottom: 1px dotted var(--accent-dim);" target="_blank" rel="noopener">github.com/scrollinondubs/allbets</a>. TypeScript. Cloudflare Workers + Hono. ~600 lines including all three adapters.
+      </p>
+      <p class="muted">
+        Pull requests welcome. New venue? Implement <code>VenueAdapter</code> in <code>src/adapters/</code>. New tool? Add it to <code>src/tools.ts</code>. The matcher is in <code>src/matcher.ts</code> and is intentionally simple right now &mdash; an LLM-judge upgrade is queued for v0.2.
+      </p>
+    </section>
+
+    <footer>
+      <div>built at agents day lisbon · 2026-05-01 · sean tierney + jax</div>
+      <div>
+        <a href="https://github.com/scrollinondubs/allbets" target="_blank" rel="noopener">github</a>
+        &nbsp;·&nbsp;
+        <a href="/mcp">/mcp</a>
+        &nbsp;·&nbsp;
+        <a href="/health">/health</a>
+      </div>
+    </footer>
+  </main>
+
+  <script>
+    (function() {
+      var phrases = [
+        "Where can my agent ",
+        "<em>actually</em> place this bet?"
+      ];
+      var target = document.getElementById("typed");
+      if (!target) return;
+      var full = phrases.join("");
+      var i = 0;
+      function tick() {
+        if (i > full.length) return;
+        target.innerHTML = full.slice(0, i);
+        i += 1;
+        setTimeout(tick, 32 + Math.random() * 24);
+      }
+      setTimeout(tick, 250);
+    })();
+  </script>
+</body>
+</html>`;

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -30,6 +30,10 @@ export const ResolutionStatusSchema = z.enum([
 
 export type Chain = "polygon" | "base" | "ethereum" | "centralized";
 
+export type SettlementRisk = "low" | "moderate" | "high";
+
+export const SettlementRiskSchema = z.enum(["low", "moderate", "high"]);
+
 export const NormalizedMarketSchema = z.object({
   venue: VenueSchema,
   venue_market_id: z.string(),
@@ -52,6 +56,12 @@ export const NormalizedMarketSchema = z.object({
   ends_at: z.string().optional(),
   resolution_status: ResolutionStatusSchema,
   dispute_open_until: z.string().optional(),
+  settlement_risk: SettlementRiskSchema,
+  settlement_risk_reason: z.string(),
+  uma_resolution_statuses: z.array(z.string()).optional(),
+  uma_bond: z.number().nonnegative().optional(),
+  uma_reward: z.number().nonnegative().optional(),
+  custom_liveness_seconds: z.number().nonnegative().optional(),
   chain: z.enum(["polygon", "base", "ethereum", "centralized"]),
   collateral_token: z.string(),
   restricted_jurisdictions: z.array(z.string()).optional(),

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { ADAPTERS, discover, fanOutSearch } from "./discovery.js";
+import { PolymarketAdapter } from "./adapters/polymarket.js";
 import type { NormalizedMarket } from "./schema.js";
 
 export const VenueArgSchema = z
@@ -23,6 +24,14 @@ export const ListActiveInputSchema = z.object({
   venues: VenueArgSchema,
 });
 
+export const QuoteInputSchema = z.object({
+  market: z.string().min(1),
+});
+
+export const DisputesActiveInputSchema = z.object({
+  limit: z.number().int().positive().max(50).default(20),
+});
+
 export const TOOL_DEFS = [
   {
     name: "pm_discover",
@@ -41,6 +50,32 @@ export const TOOL_DEFS = [
         limit_per_venue: { type: "number", default: 15 },
       },
       required: ["hypothesis"],
+    },
+  },
+  {
+    name: "pm_quote",
+    description:
+      "Single-market deep-dive. Pass a market URL (Polymarket / Kalshi / Limitless) or a 'venue:id' shorthand (e.g. 'polymarket:540816' or 'kalshi:KXFEDMTG-26JUN-T5'). Returns the fully-loaded normalized market including settlement risk badge (UMA dispute window, bond/reward, resolution status). Use this AFTER pm_discover to get the trust shape behind a price.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        market: {
+          type: "string",
+          description: "Market URL or 'venue:id' shorthand. Examples: 'https://polymarket.com/event/...', 'polymarket:540816', 'kalshi:KXFEDMTG-26JUN-T5', 'limitless:0x...'",
+        },
+      },
+      required: ["market"],
+    },
+  },
+  {
+    name: "pm_disputes_active",
+    description:
+      "Returns Polymarket markets currently flagged with UMA dispute risk (proposed-but-not-finalized OR actively disputed). Polymarket flipped over $30M of resolutions via UMA disputes in 2025 alone — agents holding positions in these markets should know.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: { type: "number", default: 20 },
+      },
     },
   },
   {
@@ -69,10 +104,86 @@ export const TOOL_DEFS = [
   },
 ];
 
+function resolveMarketRef(input: string): { venue: NormalizedMarket["venue"]; id: string } | null {
+  const trimmed = input.trim();
+
+  // venue:id shorthand
+  const shortMatch = trimmed.match(/^(polymarket|kalshi|limitless):(.+)$/i);
+  if (shortMatch) {
+    return {
+      venue: shortMatch[1]!.toLowerCase() as NormalizedMarket["venue"],
+      id: shortMatch[2]!.trim(),
+    };
+  }
+
+  // URL form
+  try {
+    const url = new URL(trimmed);
+    const host = url.hostname.toLowerCase();
+    const path = url.pathname.replace(/\/+$/, "");
+    if (host.endsWith("polymarket.com")) {
+      // /event/<slug> or /market/<id>
+      const segments = path.split("/").filter(Boolean);
+      const idx = segments.findIndex((s) => s === "event" || s === "market");
+      const id = idx >= 0 && segments[idx + 1] ? segments[idx + 1]! : segments[segments.length - 1] ?? "";
+      return id ? { venue: "polymarket", id } : null;
+    }
+    if (host.endsWith("kalshi.com")) {
+      // /markets/<event_ticker>/<ticker>
+      const segments = path.split("/").filter(Boolean);
+      const ticker = segments[segments.length - 1] ?? "";
+      return ticker ? { venue: "kalshi", id: ticker } : null;
+    }
+    if (host.endsWith("limitless.exchange")) {
+      const segments = path.split("/").filter(Boolean);
+      const id = segments[segments.length - 1] ?? "";
+      return id ? { venue: "limitless", id } : null;
+    }
+  } catch {
+    // not a URL
+  }
+  return null;
+}
+
 export async function runTool(name: string, args: unknown): Promise<unknown> {
   if (name === "pm_discover") {
     const { hypothesis, jurisdiction, limit_per_venue } = DiscoverInputSchema.parse(args);
     return discover(hypothesis, jurisdiction, limit_per_venue);
+  }
+  if (name === "pm_quote") {
+    const { market } = QuoteInputSchema.parse(args);
+    const ref = resolveMarketRef(market);
+    if (!ref) {
+      return {
+        error: "could_not_parse_market_ref",
+        input: market,
+        accepted_forms: [
+          "venue:id (e.g. 'polymarket:540816', 'kalshi:KXFEDMTG-26JUN-T5')",
+          "polymarket.com URL",
+          "kalshi.com URL",
+          "limitless.exchange URL",
+        ],
+      };
+    }
+    const adapter = ADAPTERS.find((a) => a.venue === ref.venue);
+    if (!adapter) return { error: "unknown_venue", venue: ref.venue };
+    const m = await adapter.getMarket(ref.id);
+    if (!m) return { error: "market_not_found", venue: ref.venue, id: ref.id };
+    return { quote: m };
+  }
+  if (name === "pm_disputes_active") {
+    const { limit } = DisputesActiveInputSchema.parse(args);
+    const adapter = ADAPTERS.find((a) => a.venue === "polymarket");
+    const polymarket = adapter as PolymarketAdapter | undefined;
+    if (!polymarket || typeof polymarket.listDisputed !== "function") {
+      return { count: 0, markets: [], note: "no adapter exposes dispute listing" };
+    }
+    const markets = await polymarket.listDisputed(limit);
+    return {
+      count: markets.length,
+      note: "Polymarket UMA-flagged markets only. Kalshi and Limitless settle deterministically and have no analogous dispute risk.",
+      markets,
+    };
   }
   if (name === "pm_search") {
     const { query, limit_per_venue, venues } = SearchInputSchema.parse(args);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { TOOL_DEFS, runTool } from "./tools.js";
+import { LANDING_HTML } from "./landing.js";
 
 interface JsonRpcRequest {
   jsonrpc: "2.0";
@@ -11,11 +12,17 @@ interface JsonRpcRequest {
 const app = new Hono();
 
 app.get("/", (c) =>
+  c.html(LANDING_HTML, 200, {
+    "cache-control": "public, max-age=60",
+  }),
+);
+
+app.get("/info", (c) =>
   c.json({
     name: "allbets-mcp",
     version: "0.1.1",
     description:
-      "Cross-venue prediction-market discovery. Tells your agent what bet exists across Polymarket, Kalshi, and Limitless — and where to place it.",
+      "Cross-venue prediction-market discovery. Tells your agent what bet exists across Polymarket, Kalshi, and Limitless and where to place it.",
     mcp_endpoint: "/mcp",
     tools: TOOL_DEFS.map((t) => t.name),
     docs: "https://github.com/scrollinondubs/allbets",


### PR DESCRIPTION
## Summary

Phase 2 of the Settle MVP per the PR #2 lock-in. Adds the **settlement-risk badge** as the agent capability that no other prediction-market MCP surfaces, plus the two new tools needed to expose it.

**Live:** https://allbets.dev/mcp deployed with this branch's code. `tools/list` now returns 5 tools.

## What's in scope

### Schema (flat, per Marc's spec)

- `settlement_risk: 'low' | 'moderate' | 'high'` — every market, every venue
- `settlement_risk_reason: string` — human-readable rationale
- `uma_resolution_statuses?: string[]`
- `uma_bond?: number`
- `uma_reward?: number`
- `custom_liveness_seconds?: number`
- `dispute_open_until?: string` (already in v0.1.1, now populated)

### Polymarket adapter

- Surface UMA fields from Gamma (`umaResolutionStatuses`, `umaBond`, `umaReward`, `customLiveness`, `acceptingOrdersTimestamp`)
- Compute `dispute_open_until` from `acceptingOrdersTimestamp + customLiveness` when status ∈ {`proposed`, `disputed`}
- `settlement_risk` formula matches the locked spec exactly:
  - **HIGH:** `uma_resolution_statuses` contains `proposed` | `disputed`, OR (`now < dispute_open_until`)
  - **MODERATE:** `custom_liveness_seconds > 86400`, OR `uma_bond < 500` (Polymarket default), OR `description.length < 200` (resolution-rules ambiguity proxy)
  - **LOW:** everything else
- New `listDisputed()` scans Gamma for HIGH-risk markets, sorted by `dispute_open_until` ascending

### Kalshi + Limitless adapters

- `settlement_risk: 'low'` unconditionally with appropriate reason (`'kalshi central clearinghouse, no dispute window'` / `'limitless deterministic pyth oracle resolution'`)
- Uniform schema: agent gets confirmation that those settlement models are reliable, not silent absence

### New tools

- **`pm_quote(market_url_or_id)`** — single-market deep-dive. Accepts `'venue:id'` shorthand (e.g. `'polymarket:540816'`, `'kalshi:KXFEDMTG-26JUN-T5'`) or full URLs (`polymarket.com`, `kalshi.com`, `limitless.exchange`). Returns full normalized market with the risk badge.
- **`pm_disputes_active(limit?)`** — Polymarket markets currently UMA-flagged. Sorted by `dispute_open_until` ascending so the most-urgent ones surface first.

### Docs

- README updated with 5-tool table + settlement-risk explanation block
- Landing page (`src/landing.ts`) updated to surface `pm_quote` / `pm_disputes_active` / settlement-risk in the capabilities section

## Out of scope (v0.2 layer)

- LLM-judge ambiguity scoring (replaces the `description.length < 200` heuristic)
- Cloudflare Workflows `pm_watch` daemon
- Cloudflare Email Service alerting
- x402 paywall via mpp-proxy
- AI Search hybrid index
- Kalshi/Limitless settlement-risk dimensions beyond LOW

## Demo flow

```bash
# 1. Discover what's tradable on a hypothesis
curl -X POST https://allbets.dev/mcp -H "Content-Type: application/json" -d '{
  "jsonrpc":"2.0","id":1,"method":"tools/call",
  "params":{"name":"pm_discover","arguments":{"hypothesis":"Russia-Ukraine ceasefire by Q3 2026","jurisdiction":"non_us"}}
}'

# 2. Quote a specific market with the risk badge
curl -X POST https://allbets.dev/mcp -H "Content-Type: application/json" -d '{
  "jsonrpc":"2.0","id":2,"method":"tools/call",
  "params":{"name":"pm_quote","arguments":{"market":"polymarket:<id-from-step-1>"}}
}'

# 3. List what's actively disputed RIGHT NOW
curl -X POST https://allbets.dev/mcp -H "Content-Type: application/json" -d '{
  "jsonrpc":"2.0","id":3,"method":"tools/call",
  "params":{"name":"pm_disputes_active","arguments":{"limit":10}}
}'
```

## Notes

- Branch base is `init` (default branch).
- Phase 3 (demo polish, fallback screencast, pitch script) is the next 60-min block before code freeze.
