### PR TITLE
feat(v0.1.6): pm_recommend — personalized bet discovery from URL

### DIFF
--- a/src/adapters/kalshi.ts
+++ b/src/adapters/kalshi.ts
@@ -28,17 +28,40 @@ interface KalshiEvent {
   markets?: KalshiMarket[];
 }
 
+interface KalshiSeries {
+  ticker: string;
+  title?: string;
+}
+
 interface KalshiEventsResponse {
   events?: KalshiEvent[];
   cursor?: string;
 }
 
-interface KalshiMarketsResponse {
-  markets?: KalshiMarket[];
+interface KalshiSeriesResponse {
+  series?: KalshiSeries[];
   cursor?: string;
 }
 
 const PARLAY_PREFIXES = ["KXMVE"];
+
+const SYNONYMS: Record<string, string[]> = {
+  fed: ["fed", "fomc", "powell", "federal", "reserve"],
+  cut: ["cut", "decrease", "lower", "reduce"],
+  raise: ["raise", "hike", "increase"],
+  rate: ["rate", "rates", "interest", "bps"],
+};
+
+function expandTokens(tokens: string[]): string[] {
+  const out = new Set<string>();
+  for (const t of tokens) {
+    out.add(t);
+    for (const group of Object.values(SYNONYMS)) {
+      if (group.includes(t)) for (const v of group) out.add(v);
+    }
+  }
+  return Array.from(out);
+}
 
 function isParlay(ticker: string, marketType?: string, seriesTicker?: string): boolean {
   if (marketType === "multi_leg") return true;
@@ -117,7 +140,7 @@ function toNormalized(m: KalshiMarket, eventTitle?: string): NormalizedMarket {
   };
 }
 
-async function fetchEventsWithMarkets(maxEvents = 200): Promise<KalshiEvent[]> {
+async function fetchEventsByCursor(maxEvents = 200): Promise<KalshiEvent[]> {
   const out: KalshiEvent[] = [];
   let cursor: string | undefined;
   for (let page = 0; page < 4; page++) {
@@ -142,11 +165,47 @@ async function fetchEventsWithMarkets(maxEvents = 200): Promise<KalshiEvent[]> {
   return out;
 }
 
+async function fetchEventsForSeries(seriesTicker: string): Promise<KalshiEvent[]> {
+  const url = new URL(`${KALSHI_BASE}/events`);
+  url.searchParams.set("series_ticker", seriesTicker);
+  url.searchParams.set("status", "open");
+  url.searchParams.set("limit", "50");
+  url.searchParams.set("with_nested_markets", "true");
+  const res = await fetch(url);
+  if (!res.ok) return [];
+  const json = (await res.json()) as KalshiEventsResponse;
+  return json.events ?? [];
+}
+
+async function findMatchingSeries(queryTokens: string[]): Promise<string[]> {
+  if (queryTokens.length === 0) return [];
+  const expanded = expandTokens(queryTokens.map((t) => t.toLowerCase()));
+  const url = new URL(`${KALSHI_BASE}/series`);
+  url.searchParams.set("limit", "200");
+  url.searchParams.set("include_product_metadata", "false");
+  const res = await fetch(url);
+  if (!res.ok) return [];
+  const json = (await res.json()) as KalshiSeriesResponse;
+  const series = json.series ?? [];
+
+  const scored = series.map((s) => {
+    const haystack = `${s.title ?? ""} ${s.ticker ?? ""}`.toLowerCase();
+    let score = 0;
+    for (const t of expanded) if (haystack.includes(t)) score += 1;
+    return { ticker: s.ticker, score };
+  });
+  scored.sort((a, b) => b.score - a.score);
+  return scored.filter((s) => s.score > 0).slice(0, 3).map((s) => s.ticker);
+}
+
 function flattenMarkets(events: KalshiEvent[]): Array<{ market: KalshiMarket; eventTitle?: string }> {
+  const seen = new Set<string>();
   const out: Array<{ market: KalshiMarket; eventTitle?: string }> = [];
   for (const e of events) {
     for (const m of e.markets ?? []) {
+      if (seen.has(m.ticker)) continue;
       if (isParlay(m.ticker, m.market_type, e.series_ticker)) continue;
+      seen.add(m.ticker);
       out.push({ market: m, eventTitle: e.title });
     }
   }
@@ -157,16 +216,25 @@ export class KalshiAdapter implements VenueAdapter {
   readonly venue = "kalshi" as const;
 
   async searchMarkets(query: string, limit = 10): Promise<NormalizedMarket[]> {
-    const events = await fetchEventsWithMarkets(200);
-    const flat = flattenMarkets(events);
-    const q = query.toLowerCase();
-    const tokens = q.replace(/[^a-z0-9\s]/g, " ").split(/\s+/).filter((t) => t.length > 2);
+    const tokens = query.toLowerCase().replace(/[^a-z0-9\s]/g, " ").split(/\s+/).filter((t) => t.length > 2);
+
+    // Series-targeted fetch + general events fetch in parallel
+    const [seriesTickers, generalEvents] = await Promise.all([
+      findMatchingSeries(tokens),
+      fetchEventsByCursor(200),
+    ]);
+
+    const seriesEvents = await Promise.all(seriesTickers.map(fetchEventsForSeries));
+    const allEvents: KalshiEvent[] = [...seriesEvents.flat(), ...generalEvents];
+    const flat = flattenMarkets(allEvents);
+
     if (tokens.length === 0) return flat.slice(0, limit).map((x) => toNormalized(x.market, x.eventTitle));
 
+    const expandedTokens = expandTokens(tokens);
     const scored = flat.map((x) => {
       const haystack = `${x.market.title ?? ""} ${x.market.subtitle ?? ""} ${x.eventTitle ?? ""}`.toLowerCase();
       let score = 0;
-      for (const t of tokens) if (haystack.includes(t)) score += 1;
+      for (const t of expandedTokens) if (haystack.includes(t)) score += 1;
       return { x, score };
     });
     scored.sort((a, b) => b.score - a.score);
@@ -187,7 +255,7 @@ export class KalshiAdapter implements VenueAdapter {
   }
 
   async listActive(limit = 25): Promise<NormalizedMarket[]> {
-    const events = await fetchEventsWithMarkets(200);
+    const events = await fetchEventsByCursor(200);
     const flat = flattenMarkets(events);
     return flat.slice(0, limit).map((x) => toNormalized(x.market, x.eventTitle));
   }

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -5,6 +5,41 @@ import type { VenueAdapter } from "./adapters/types.js";
 import type { DiscoveryReport, NormalizedMarket, VenueDiscoveryResult } from "./schema.js";
 import { bestMatchPerVenue } from "./matcher.js";
 
+function slim(m: NormalizedMarket): NormalizedMarket {
+  return {
+    venue: m.venue,
+    venue_market_id: m.venue_market_id,
+    event_id: m.event_id,
+    event_question: m.event_question,
+    question: m.question,
+    outcomes: m.outcomes.map((o) => ({
+      label: o.label,
+      probability: Math.round(o.probability * 1000) / 1000,
+      bid: o.bid,
+      ask: o.ask,
+      tradable_outcome_id: o.tradable_outcome_id,
+    })),
+    liquidity_usd: m.liquidity_usd,
+    volume_usd: m.volume_usd,
+    open_interest_usd: m.open_interest_usd,
+    ends_at: m.ends_at,
+    resolution_status: m.resolution_status,
+    dispute_open_until: m.dispute_open_until,
+    settlement_risk: m.settlement_risk,
+    settlement_risk_reason: m.settlement_risk_reason,
+    uma_resolution_statuses: m.uma_resolution_statuses,
+    uma_bond: m.uma_bond,
+    uma_reward: m.uma_reward,
+    custom_liveness_seconds: m.custom_liveness_seconds,
+    chain: m.chain,
+    collateral_token: m.collateral_token,
+    restricted_jurisdictions: m.restricted_jurisdictions,
+    is_parlay: m.is_parlay,
+    is_auto_generated: m.is_auto_generated,
+    url: m.url,
+  };
+}
+
 export const ADAPTERS: VenueAdapter[] = [
   new PolymarketAdapter(),
   new KalshiAdapter(),
@@ -123,7 +158,7 @@ export async function discover(
         venue,
         has_match: false,
         match_count: sameVenueMarkets.length,
-        adjacent_matches: sameVenueMarkets.slice(0, 3),
+        adjacent_matches: sameVenueMarkets.slice(0, 3).map(slim),
         unavailable_reason: error
           ? `venue API error: ${error}`
           : blocked
@@ -138,7 +173,7 @@ export async function discover(
         venue,
         has_match: false,
         match_count: best.adjacent.length + 1,
-        adjacent_matches: [best.market, ...best.adjacent],
+        adjacent_matches: [best.market, ...best.adjacent].map(slim),
         unavailable_reason: "blocked by jurisdiction",
         jurisdiction_note: note,
       };
@@ -147,8 +182,8 @@ export async function discover(
       venue,
       has_match: true,
       match_count: best.adjacent.length + 1,
-      best_match: best.market,
-      adjacent_matches: best.adjacent,
+      best_match: slim(best.market),
+      adjacent_matches: best.adjacent.map(slim),
       jurisdiction_note: note,
     };
   });

--- a/src/landing.ts
+++ b/src/landing.ts
@@ -457,12 +457,16 @@ export const LANDING_HTML = `<!doctype html>
     <section>
       <h2><span class="num">02</span>What allbets does</h2>
       <p>
-        One MCP endpoint over <strong>Streamable HTTP</strong>. Five tools. Read-only. Public APIs only. No keys at runtime.
+        One MCP endpoint over <strong>Streamable HTTP</strong>. Six tools. Read-only. Public APIs only.
       </p>
 
       <div class="feature-row">
         <div class="label">pm_discover</div>
         <div class="body">Hand it a hypothesis and a jurisdiction. Returns what each venue lists, the depth of liquidity, the resolution model, and a single recommended trade-here URL. The primary entry tool.</div>
+      </div>
+      <div class="feature-row">
+        <div class="label">pm_recommend</div>
+        <div class="body">Hand it your blog or personal-site URL. Scrapes the page, extracts your topics + stances, and returns up to 10 ranked prediction-market bets across all three venues that match what you actually care about. Stateless &mdash; nothing persisted.</div>
       </div>
       <div class="feature-row">
         <div class="label">pm_quote</div>

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -3,8 +3,36 @@ import type { NormalizedMarket } from "./schema.js";
 const STOPWORDS = new Set([
   "the","a","an","is","are","will","be","to","in","on","of","for","by","and",
   "or","vs","before","after","this","that","with","at","by","when","does","do",
-  "did","get","its","it","s","t",
+  "did","get","its","it","s","t","odds","what","how","much","many","probability",
 ]);
+
+const SYNONYM_GROUPS: string[][] = [
+  ["cut", "cuts", "cutting", "decrease", "decreases", "decreased", "lower", "lowers", "lowered", "reduce", "reduces", "reduced", "drop", "drops", "dropped", "fall", "falls", "fell"],
+  ["raise", "raises", "raised", "hike", "hikes", "hiked", "increase", "increases", "increased", "boost", "boosts", "rise", "rises", "rose"],
+  ["fed", "fomc", "powell", "federal", "reserve"],
+  ["rate", "rates", "interest", "bps"],
+  ["june", "jun"],
+  ["july", "jul"],
+  ["may"],
+];
+
+function expandToken(t: string): string[] {
+  for (const group of SYNONYM_GROUPS) {
+    if (group.includes(t)) return group;
+  }
+  return [t];
+}
+
+function antonymTokens(t: string): string[] {
+  for (let i = 0; i < SYNONYM_GROUPS.length; i++) {
+    if (SYNONYM_GROUPS[i]!.includes(t)) {
+      // antonym pair: cut/decrease group <-> raise/increase group
+      if (i === 0) return SYNONYM_GROUPS[1]!;
+      if (i === 1) return SYNONYM_GROUPS[0]!;
+    }
+  }
+  return [];
+}
 
 function tokenize(s: string): string[] {
   return s
@@ -14,13 +42,29 @@ function tokenize(s: string): string[] {
     .filter((t) => t.length > 1 && !STOPWORDS.has(t));
 }
 
-function jaccard(a: string[], b: string[]): number {
-  const sa = new Set(a);
-  const sb = new Set(b);
-  let intersection = 0;
-  for (const t of sa) if (sb.has(t)) intersection++;
-  const union = sa.size + sb.size - intersection;
-  return union === 0 ? 0 : intersection / union;
+export function scoreMarket(queryTokens: string[], market: NormalizedMarket): number {
+  const haystack = `${market.question ?? ""} ${market.event_question ?? ""}`.toLowerCase();
+  let score = 0;
+  for (const t of queryTokens) {
+    const expanded = expandToken(t);
+    let hit = false;
+    for (const variant of expanded) {
+      if (haystack.includes(variant)) {
+        hit = true;
+        break;
+      }
+    }
+    if (hit) score += 1;
+
+    const antonyms = antonymTokens(t);
+    for (const ant of antonyms) {
+      if (haystack.includes(ant)) {
+        score -= 1.5; // antonym penalty stronger than synonym credit
+        break;
+      }
+    }
+  }
+  return score;
 }
 
 export interface VenueBest {
@@ -32,7 +76,7 @@ export interface VenueBest {
 export function bestMatchPerVenue(
   hypothesis: string,
   markets: NormalizedMarket[],
-  threshold = 0.25,
+  threshold = 0.5,
 ): Map<NormalizedMarket["venue"], VenueBest> {
   const queryTokens = tokenize(hypothesis);
   const byVenue = new Map<NormalizedMarket["venue"], NormalizedMarket[]>();
@@ -44,13 +88,7 @@ export function bestMatchPerVenue(
 
   const result = new Map<NormalizedMarket["venue"], VenueBest>();
   for (const [venue, list] of byVenue) {
-    const scored = list.map((m) => {
-      const qScore = jaccard(queryTokens, tokenize(m.question));
-      const eScore = m.event_question
-        ? jaccard(queryTokens, tokenize(m.event_question))
-        : 0;
-      return { market: m, score: Math.max(qScore, eScore) };
-    });
+    const scored = list.map((m) => ({ market: m, score: scoreMarket(queryTokens, m) }));
     scored.sort((a, b) => b.score - a.score);
     const top = scored[0];
     if (!top || top.score < threshold) continue;

--- a/src/recommend.ts
+++ b/src/recommend.ts
@@ -1,0 +1,349 @@
+import type { NormalizedMarket } from "./schema.js";
+import { discover } from "./discovery.js";
+
+export interface ExtractedProfile {
+  topics: string[];
+  stances: Array<{ topic: string; direction: "bullish" | "bearish" | "neutral"; horizon?: string }>;
+  industries?: string[];
+  geographic_focus?: string[];
+  summary: string;
+}
+
+export interface Recommendation {
+  market: NormalizedMarket;
+  relevance_to: string;
+  rank_score: number;
+  rationale: string;
+}
+
+export interface RecommendReport {
+  profile_url: string;
+  jurisdiction: "us" | "non_us" | "unknown";
+  extracted: ExtractedProfile;
+  recommendations: Recommendation[];
+  jurisdiction_filtered_count: number;
+  warnings: string[];
+}
+
+interface WorkersAI {
+  run(model: string, input: Record<string, unknown>): Promise<unknown>;
+}
+
+interface Env {
+  FIRECRAWL_API_KEY?: string;
+  ANTHROPIC_API_KEY?: string;
+  AI?: WorkersAI;
+}
+
+const FIRECRAWL_BASE = "https://api.firecrawl.dev/v1";
+const ANTHROPIC_BASE = "https://api.anthropic.com/v1";
+const ANTHROPIC_MODEL = "claude-haiku-4-5-20251001";
+const WORKERS_AI_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast";
+const SCRAPE_TIMEOUT_MS = 25000;
+const MAX_MARKDOWN_CHARS = 50000;
+
+async function firecrawlScrape(url: string, apiKey: string): Promise<string> {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), SCRAPE_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${FIRECRAWL_BASE}/scrape`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        url,
+        formats: ["markdown"],
+        onlyMainContent: true,
+      }),
+      signal: ctrl.signal,
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`firecrawl ${res.status}: ${body.slice(0, 200)}`);
+    }
+    const json = (await res.json()) as { data?: { markdown?: string } };
+    const md = json.data?.markdown ?? "";
+    return md.slice(0, MAX_MARKDOWN_CHARS);
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+const EXTRACTION_SYSTEM_PROMPT = `You analyze a person's writing or profile and extract their interests, stances, and what they care about. The downstream consumer is a prediction-market discovery tool, so topics need to be SPECIFIC enough to find real-world events, not generic categories.
+
+Respond ONLY with valid JSON matching this exact schema:
+
+{
+  "topics": ["string", ...],
+  "stances": [{"topic": "string", "direction": "bullish" | "bearish" | "neutral", "horizon": "string"}, ...],
+  "industries": ["string", ...],
+  "geographic_focus": ["string", ...],
+  "summary": "string"
+}
+
+Rules for topics:
+- 3-7 specific topical keywords/phrases that name a CONCRETE event, person, company, technology, geography, or asset that could be the subject of a prediction-market question.
+- GOOD: "AI coding agents", "OpenAI", "Anthropic", "GPT-5 release", "Bitcoin halving", "Powell rate decision", "Trump tariffs", "Lisbon real estate prices", "Solana ETF approval", "Polymarket"
+- BAD (too generic, will match noise): "software development", "technology", "business", "innovation", "education", "AI", "the future"
+- Each topic should contain at least one PROPER NOUN or distinctive 5+ letter word. Avoid bare adjectives or common verbs.
+- Lowercase or natural case. No hashtags.
+
+Rules for stances:
+- Only include if the person expresses a clear directional view; if they're descriptive without a position, omit.
+- direction must be one of: bullish | bearish | neutral. horizon if mentioned ("short-term", "12 months", "by 2030"); omit otherwise.
+
+Other:
+- industries: their professional / sector focus (less critical, can be generic).
+- geographic_focus: locations or markets they discuss.
+- summary: ONE sentence describing this person's interests and worldview, in third person.
+- Return ONLY the JSON object. No prose before or after. No markdown fences.`;
+
+function parseExtractedJson(text: string): ExtractedProfile {
+  const cleaned = text
+    .replace(/^```json\s*/i, "")
+    .replace(/^```\s*/i, "")
+    .replace(/```\s*$/, "")
+    .trim();
+  // try to locate JSON object boundaries if the model added prose
+  const start = cleaned.indexOf("{");
+  const end = cleaned.lastIndexOf("}");
+  const candidate = start >= 0 && end > start ? cleaned.slice(start, end + 1) : cleaned;
+  let parsed: ExtractedProfile;
+  try {
+    parsed = JSON.parse(candidate) as ExtractedProfile;
+  } catch {
+    throw new Error(`failed to parse extraction JSON: ${candidate.slice(0, 200)}`);
+  }
+  if (!Array.isArray(parsed.topics) || parsed.topics.length === 0) {
+    throw new Error("extraction returned no topics");
+  }
+  parsed.topics = parsed.topics.slice(0, 7);
+  parsed.stances = (parsed.stances ?? []).slice(0, 7);
+  return parsed;
+}
+
+async function extractViaWorkersAI(markdown: string, ai: WorkersAI): Promise<ExtractedProfile> {
+  const trimmed = markdown.slice(0, 30000);
+  const result = (await ai.run(WORKERS_AI_MODEL, {
+    messages: [
+      { role: "system", content: EXTRACTION_SYSTEM_PROMPT },
+      { role: "user", content: `Analyze this profile content and return the JSON:\n\n---\n\n${trimmed}` },
+    ],
+    response_format: { type: "json_object" },
+    max_tokens: 1024,
+    temperature: 0.2,
+  })) as { response?: string } | string;
+
+  const text =
+    typeof result === "string"
+      ? result
+      : typeof result?.response === "string"
+        ? result.response
+        : JSON.stringify(result);
+  return parseExtractedJson(text);
+}
+
+async function extractViaAnthropic(markdown: string, apiKey: string): Promise<ExtractedProfile> {
+  const trimmed = markdown.slice(0, 30000);
+  const res = await fetch(`${ANTHROPIC_BASE}/messages`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model: ANTHROPIC_MODEL,
+      max_tokens: 1024,
+      system: EXTRACTION_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: "user",
+          content: `Analyze this profile content and return the JSON:\n\n---\n\n${trimmed}`,
+        },
+      ],
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`anthropic ${res.status}: ${body.slice(0, 200)}`);
+  }
+  const json = (await res.json()) as { content: Array<{ type: string; text?: string }> };
+  const text = json.content.find((b) => b.type === "text")?.text ?? "";
+  return parseExtractedJson(text);
+}
+
+async function extractProfile(markdown: string, env: Env, warnings: string[]): Promise<ExtractedProfile> {
+  if (env.AI) {
+    try {
+      return await extractViaWorkersAI(markdown, env.AI);
+    } catch (err) {
+      warnings.push(`Workers AI extraction failed (${err instanceof Error ? err.message : String(err)}), falling back to Anthropic`);
+    }
+  }
+  if (env.ANTHROPIC_API_KEY) {
+    return extractViaAnthropic(markdown, env.ANTHROPIC_API_KEY);
+  }
+  throw new Error("no extraction backend configured: need AI binding or ANTHROPIC_API_KEY");
+}
+
+const MIN_RANK_SCORE = 2.5;
+
+const GENERIC_TOKENS = new Set([
+  "software", "development", "technology", "business", "innovation",
+  "education", "industry", "company", "service", "platform", "product",
+  "system", "solution", "data", "team", "world", "people", "thing", "stuff",
+  "labor", "cabinet", "house", "general", "national", "state", "federal",
+]);
+
+function distinctiveTopicTokens(topic: string): Set<string> {
+  return new Set(
+    topic
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, " ")
+      .split(/\s+/)
+      .filter((t) => t.length > 3 && !GENERIC_TOKENS.has(t)),
+  );
+}
+
+function topicOverlapsMarket(topic: string, market: NormalizedMarket): boolean {
+  const t = distinctiveTopicTokens(topic);
+  if (t.size === 0) return false; // topic is too generic — drop entirely
+  const haystack = `${market.question} ${market.event_question ?? ""} ${market.description ?? ""}`.toLowerCase();
+  for (const tok of t) {
+    if (haystack.includes(tok)) return true;
+  }
+  return false;
+}
+
+function rankAndDedupe(
+  candidates: Array<{ topic: string; market: NormalizedMarket }>,
+  stances: ExtractedProfile["stances"],
+  max: number,
+): Recommendation[] {
+  const byMarket = new Map<string, { topics: Set<string>; market: NormalizedMarket }>();
+  for (const c of candidates) {
+    if (!topicOverlapsMarket(c.topic, c.market)) continue;
+    const key = `${c.market.venue}:${c.market.venue_market_id}`;
+    const ex = byMarket.get(key);
+    if (ex) {
+      ex.topics.add(c.topic);
+    } else {
+      byMarket.set(key, { topics: new Set([c.topic]), market: c.market });
+    }
+  }
+
+  const stanceByTopic = new Map<string, ExtractedProfile["stances"][number]>();
+  for (const s of stances) stanceByTopic.set(s.topic.toLowerCase(), s);
+
+  const recommendations: Recommendation[] = [];
+  for (const { topics, market } of byMarket.values()) {
+    let score = 0;
+    let relevance_to = Array.from(topics).join(", ");
+    let rationale = `matches your interest in ${relevance_to}`;
+
+    score += topics.size * 1.5; // multi-topic match boost
+
+    const liq = market.liquidity_usd ?? 0;
+    const vol = market.volume_usd ?? 0;
+    if (liq > 100000) score += 2.0;
+    else if (liq > 10000) score += 1.0;
+    else if (liq > 0) score += 0.25;
+
+    if (vol > 100000) score += 1.0;
+    else if (vol > 10000) score += 0.25;
+
+    // Drop markets with no real activity unless they're high-event interest
+    if (liq === 0 && vol < 10000) score -= 1.5;
+
+    if (market.settlement_risk === "low") score += 0.5;
+    if (market.settlement_risk === "high") score -= 0.5;
+
+    if (market.is_auto_generated) score -= 0.5;
+    if (market.is_parlay) score -= 1.5;
+
+    for (const topic of topics) {
+      const stance = stanceByTopic.get(topic.toLowerCase());
+      if (!stance) continue;
+      score += 0.75; // we have a stance signal
+      const yes = market.outcomes.find((o) => /yes/i.test(o.label));
+      const yesProb = yes?.probability ?? 0.5;
+      if (stance.direction === "bullish" && yesProb >= 0.4) {
+        score += 1.0;
+        rationale = `matches your bullish stance on ${stance.topic} — ${(yesProb * 100).toFixed(0)}% YES`;
+      } else if (stance.direction === "bearish" && yesProb <= 0.6) {
+        score += 1.0;
+        rationale = `matches your bearish stance on ${stance.topic} — ${((1 - yesProb) * 100).toFixed(0)}% NO`;
+      }
+    }
+
+    recommendations.push({ market, relevance_to, rank_score: Math.round(score * 100) / 100, rationale });
+  }
+
+  recommendations.sort((a, b) => b.rank_score - a.rank_score);
+  return recommendations.filter((r) => r.rank_score >= MIN_RANK_SCORE).slice(0, max);
+}
+
+export async function recommendFromUrl(
+  profileUrl: string,
+  jurisdiction: "us" | "non_us" | "unknown",
+  maxRecommendations: number,
+  env: Env,
+): Promise<RecommendReport> {
+  const warnings: string[] = [];
+
+  if (!env.FIRECRAWL_API_KEY) throw new Error("FIRECRAWL_API_KEY not configured on Worker");
+  if (!env.AI && !env.ANTHROPIC_API_KEY) throw new Error("no AI binding or ANTHROPIC_API_KEY on Worker");
+
+  let markdown: string;
+  try {
+    markdown = await firecrawlScrape(profileUrl, env.FIRECRAWL_API_KEY);
+  } catch (err) {
+    throw new Error(`scrape failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (!markdown || markdown.trim().length < 200) {
+    warnings.push("scraped content was very short — extraction may be unreliable");
+  }
+
+  const extracted = await extractProfile(markdown, env, warnings);
+
+  const topicResults = await Promise.allSettled(
+    extracted.topics.map((topic) => discover(topic, jurisdiction, 8)),
+  );
+
+  const candidates: Array<{ topic: string; market: NormalizedMarket }> = [];
+  let jurisdictionFiltered = 0;
+
+  topicResults.forEach((r, i) => {
+    const topic = extracted.topics[i]!;
+    if (r.status !== "fulfilled") {
+      warnings.push(`discover failed for "${topic}": ${String(r.reason).slice(0, 120)}`);
+      return;
+    }
+    for (const venueResult of r.value.per_venue) {
+      if (venueResult.unavailable_reason === "blocked by jurisdiction") {
+        jurisdictionFiltered += venueResult.match_count;
+        continue;
+      }
+      if (venueResult.best_match) {
+        candidates.push({ topic, market: venueResult.best_match });
+      }
+      for (const adj of venueResult.adjacent_matches ?? []) {
+        candidates.push({ topic, market: adj });
+      }
+    }
+  });
+
+  const recommendations = rankAndDedupe(candidates, extracted.stances ?? [], maxRecommendations);
+
+  return {
+    profile_url: profileUrl,
+    jurisdiction,
+    extracted,
+    recommendations,
+    jurisdiction_filtered_count: jurisdictionFiltered,
+    warnings,
+  };
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,7 +1,19 @@
 import { z } from "zod";
 import { ADAPTERS, discover, fanOutSearch } from "./discovery.js";
 import { PolymarketAdapter } from "./adapters/polymarket.js";
+import { recommendFromUrl } from "./recommend.js";
 import type { NormalizedMarket } from "./schema.js";
+
+interface WorkersAIBinding {
+  run(model: string, input: Record<string, unknown>): Promise<unknown>;
+}
+
+interface ToolEnv {
+  FIRECRAWL_API_KEY?: string;
+  ANTHROPIC_API_KEY?: string;
+  EXA_API_KEY?: string;
+  AI?: WorkersAIBinding;
+}
 
 export const VenueArgSchema = z
   .array(z.enum(["polymarket", "kalshi", "limitless"]))
@@ -30,6 +42,12 @@ export const QuoteInputSchema = z.object({
 
 export const DisputesActiveInputSchema = z.object({
   limit: z.number().int().positive().max(50).default(20),
+});
+
+export const RecommendInputSchema = z.object({
+  profile_url: z.string().url(),
+  jurisdiction: z.enum(["us", "non_us", "unknown"]).default("unknown"),
+  max_recommendations: z.number().int().positive().max(20).default(10),
 });
 
 export const TOOL_DEFS = [
@@ -76,6 +94,27 @@ export const TOOL_DEFS = [
       properties: {
         limit: { type: "number", default: 20 },
       },
+    },
+  },
+  {
+    name: "pm_recommend",
+    description:
+      "Personalized recommendations: scrape a profile URL (blog, Substack, personal site), extract topics + stances, then return up to N prediction-market bets across Polymarket / Kalshi / Limitless that match the person's interests. Ranked by stance-alignment + liquidity. Stateless — no URL or content persisted.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        profile_url: {
+          type: "string",
+          description: "Public URL: blog post, Substack page, personal site, etc. Twitter / LinkedIn often blocked — public blogs work most reliably.",
+        },
+        jurisdiction: {
+          type: "string",
+          enum: ["us", "non_us", "unknown"],
+          default: "unknown",
+        },
+        max_recommendations: { type: "number", default: 10 },
+      },
+      required: ["profile_url"],
     },
   },
   {
@@ -145,10 +184,14 @@ function resolveMarketRef(input: string): { venue: NormalizedMarket["venue"]; id
   return null;
 }
 
-export async function runTool(name: string, args: unknown): Promise<unknown> {
+export async function runTool(name: string, args: unknown, env: ToolEnv = {}): Promise<unknown> {
   if (name === "pm_discover") {
     const { hypothesis, jurisdiction, limit_per_venue } = DiscoverInputSchema.parse(args);
     return discover(hypothesis, jurisdiction, limit_per_venue);
+  }
+  if (name === "pm_recommend") {
+    const { profile_url, jurisdiction, max_recommendations } = RecommendInputSchema.parse(args);
+    return recommendFromUrl(profile_url, jurisdiction, max_recommendations, env);
   }
   if (name === "pm_quote") {
     const { market } = QuoteInputSchema.parse(args);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -9,7 +9,18 @@ interface JsonRpcRequest {
   params?: Record<string, unknown>;
 }
 
-const app = new Hono();
+interface WorkersAIBinding {
+  run(model: string, input: Record<string, unknown>): Promise<unknown>;
+}
+
+interface WorkerEnv {
+  FIRECRAWL_API_KEY?: string;
+  ANTHROPIC_API_KEY?: string;
+  EXA_API_KEY?: string;
+  AI?: WorkersAIBinding;
+}
+
+const app = new Hono<{ Bindings: WorkerEnv }>();
 
 app.get("/", (c) =>
   c.html(LANDING_HTML, 200, {
@@ -73,7 +84,7 @@ app.post("/mcp", async (c) => {
         const params = body.params ?? {};
         const name = params.name as string;
         const args = (params.arguments as Record<string, unknown>) ?? {};
-        const result = await runTool(name, args);
+        const result = await runTool(name, args, c.env);
         return respond({
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
         });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -14,3 +14,7 @@ preview_urls = true
 
 [observability]
 enabled = true
+
+# Workers AI: Llama-3.3-70b for pm_recommend topic extraction (replaces personal Anthropic key for cost isolation)
+[ai]
+binding = "AI"


### PR DESCRIPTION
## Summary

Implements issue #9. New tool **`pm_recommend`** turns a public URL (blog, Substack, personal site) into ranked prediction-market recommendations across all three venues.

**Live + smoke-tested on `allbets.dev/mcp`.** Tool count: 5 → 6.

## Pipeline

1. **Scrape.** `firecrawl /scrape` → markdown, 50KB cap, JS-rendered SPAs handled.
2. **Extract.** Workers AI Llama-3.3-70b-instruct-fp8-fast → structured JSON: `{topics, stances, industries, geographic_focus, summary}`. Anthropic Haiku is wired as a fallback in case Workers AI flakes.
3. **Fan out.** Each topic → existing `pm_discover()` in parallel (`allSettled`).
4. **Rank + dedupe.** Multi-topic match boost + liquidity tier + volume tier + stance alignment + settlement-risk + parlay/lumy penalties. Drop `rank_score < 2.5`.

## Cost shift

**Was:** Anthropic Haiku via Sean's personal `ANTHROPIC_API_KEY` — every call billed to his personal account.

**Now:** Workers AI Llama-3.3-70b on the `admin@allbets.dev` CF account. ~50 neurons per call. 10K neurons/day free tier covers comfortably for the hackathon. Anthropic key kept as fallback only.

## Quality fixes shipped in the same iteration

Initial run produced spam (matched on "development" / "labor" / "cabinet" in unrelated Kalshi markets). Three changes brought signal up:

- **LLM prompt tightened** with explicit GOOD/BAD topic examples. Pushes the model toward proper nouns + 5+ letter distinctive tokens. "Anthropic" / "OpenAI" / "Claude Code" instead of "AI" / "software development".
- **Generic-token blocklist** (`software`, `development`, `technology`, `labor`, `cabinet`, etc.). Topics with no distinctive tokens after blocklist are dropped entirely.
- **Distinctive-token overlap gate** — topic must share at least one 4+ letter non-generic token with the market's `question + event_question + description` text. Filters out "matched on a common English word" noise before scoring.

## Smoke test

`pm_recommend("https://scrollinondubs.substack.com")` now returns:

1. **Will Anthropic have the best AI model at end of May 2026?** — 82.5% YES, $47K liquidity, $209K volume
2. **Will OpenAI have the best AI model at end of May 2026?** — 2.2% YES, $29K liq, $255K vol
3. **Will Anthropic flip BTC by December 31?** — 41.5% YES, $24K liq, $85K vol

Topic extraction: `["Vibecode Lisboa", "GenAI tools", "Anthropic", "OpenAI", "Claude Code", "Build School", "Sean Tierney"]` with `bullish` stance on `GenAI tools` (correct given the source content).

## Carried-in fixes

These shipped in the same branch since they were on the working tree from the morning's debug loop:

- **Kalshi `/series`-aware fetch** — score open series by hypothesis tokens, fetch top-3 matching series' events in parallel with the general `/events` fetch. Fixes the "no Fed markets visible" issue (`KXFEDDECISION` series wasn't surfacing in the default `/events?status=open` page).
- **Matcher antonym penalty** — `cut/decrease/lower/reduce` vs `raise/hike/increase`. Fixes the earlier bug where "Fed cut rates" matched "Fed increase by 50+ bps" with equal token overlap.
- **Slim response projection** — `raw` API payloads stripped from `pm_discover` output. 92KB responses → ~7KB.

## Out of scope (v0.2+)

- Exa-augmented topic enrichment (search-augmented for richer topics)
- Embeddings-based topic-to-market matching (replaces token-substring with cosine similarity)
- Multi-URL ingest (blog + LinkedIn + Twitter combined)
- LinkedIn / Twitter authenticated scraping (Firecrawl handles partial; full JS-rendered scrape via CF Browser Rendering API is v0.2)
- Caching by URL with TTL
- Per-IP rate limiting

## Notes

- Branch base: `init`.
- Worker secrets in place: `FIRECRAWL_API_KEY`, `ANTHROPIC_API_KEY` (fallback), `EXA_API_KEY` (reserved for v0.2). `[ai]` binding added to `wrangler.toml`.
- **Rotation reminder:** `FIRECRAWL_API_KEY` and `EXA_API_KEY` were posted to Discord under explicit acknowledgment + rotation commitment from Sean. Tracked in memory as `task:2026-05-01-rotate-allbets-keys`. Rotate post-demo.
