### PR TITLE
fix(v0.1.7): adapter timeouts + tool-level error semantics + JSON-RPC error codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@allbets/mcp",
-  "version": "0.1.1",
+  "version": "0.1.7",
   "description": "Cross-venue prediction-market discovery MCP. Tells your agent what bet exists across Polymarket, Kalshi, and Limitless — and where to place it.",
   "type": "module",
   "main": "src/index.ts",

--- a/src/adapters/kalshi.ts
+++ b/src/adapters/kalshi.ts
@@ -2,6 +2,11 @@ import type { VenueAdapter } from "./types.js";
 import type { NormalizedMarket, ResolutionStatus } from "../schema.js";
 
 const KALSHI_BASE = "https://api.elections.kalshi.com/trade-api/v2";
+const FETCH_TIMEOUT_MS = 8000;
+
+function timed(): RequestInit {
+  return { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) };
+}
 
 interface KalshiMarket {
   ticker: string;
@@ -149,7 +154,7 @@ async function fetchEventsByCursor(maxEvents = 200): Promise<KalshiEvent[]> {
     url.searchParams.set("limit", "200");
     url.searchParams.set("with_nested_markets", "true");
     if (cursor) url.searchParams.set("cursor", cursor);
-    const res = await fetch(url);
+    const res = await fetch(url, timed());
     if (!res.ok) break;
     const json = (await res.json()) as KalshiEventsResponse;
     const events = json.events ?? [];
@@ -171,7 +176,7 @@ async function fetchEventsForSeries(seriesTicker: string): Promise<KalshiEvent[]
   url.searchParams.set("status", "open");
   url.searchParams.set("limit", "50");
   url.searchParams.set("with_nested_markets", "true");
-  const res = await fetch(url);
+  const res = await fetch(url, timed());
   if (!res.ok) return [];
   const json = (await res.json()) as KalshiEventsResponse;
   return json.events ?? [];
@@ -183,7 +188,7 @@ async function findMatchingSeries(queryTokens: string[]): Promise<string[]> {
   const url = new URL(`${KALSHI_BASE}/series`);
   url.searchParams.set("limit", "200");
   url.searchParams.set("include_product_metadata", "false");
-  const res = await fetch(url);
+  const res = await fetch(url, timed());
   if (!res.ok) return [];
   const json = (await res.json()) as KalshiSeriesResponse;
   const series = json.series ?? [];
@@ -246,7 +251,7 @@ export class KalshiAdapter implements VenueAdapter {
 
   async getMarket(venueMarketId: string): Promise<NormalizedMarket | null> {
     const ticker = venueMarketId.trim();
-    const res = await fetch(`${KALSHI_BASE}/markets/${encodeURIComponent(ticker)}`);
+    const res = await fetch(`${KALSHI_BASE}/markets/${encodeURIComponent(ticker)}`, timed());
     if (res.status === 404) return null;
     if (!res.ok) throw new Error(`kalshi getMarket failed: ${res.status}`);
     const json = (await res.json()) as { market: KalshiMarket };

--- a/src/adapters/limitless.ts
+++ b/src/adapters/limitless.ts
@@ -2,6 +2,11 @@ import type { VenueAdapter } from "./types.js";
 import type { NormalizedMarket, ResolutionStatus } from "../schema.js";
 
 const LIMITLESS_BASE = "https://api.limitless.exchange";
+const FETCH_TIMEOUT_MS = 8000;
+
+function timed(): RequestInit {
+  return { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) };
+}
 
 interface LimitlessMarket {
   address: string;
@@ -102,7 +107,7 @@ export class LimitlessAdapter implements VenueAdapter {
   readonly venue = "limitless" as const;
 
   async searchMarkets(query: string, limit = 10): Promise<NormalizedMarket[]> {
-    const res = await fetch(`${LIMITLESS_BASE}/markets/active`);
+    const res = await fetch(`${LIMITLESS_BASE}/markets/active`, timed());
     if (!res.ok) throw new Error(`limitless search failed: ${res.status}`);
     const list = unwrap(await res.json());
     const q = query.toLowerCase();
@@ -125,10 +130,10 @@ export class LimitlessAdapter implements VenueAdapter {
   async getMarket(venueMarketId: string): Promise<NormalizedMarket | null> {
     // Limitless markets endpoint accepts either address or slug
     const trimmed = venueMarketId.trim();
-    const res = await fetch(`${LIMITLESS_BASE}/markets/${encodeURIComponent(trimmed)}`);
+    const res = await fetch(`${LIMITLESS_BASE}/markets/${encodeURIComponent(trimmed)}`, timed());
     if (res.status === 404) {
       // try active list and match
-      const active = await fetch(`${LIMITLESS_BASE}/markets/active`);
+      const active = await fetch(`${LIMITLESS_BASE}/markets/active`, timed());
       if (!active.ok) return null;
       const list = unwrap(await active.json());
       const found = list.find(
@@ -142,7 +147,7 @@ export class LimitlessAdapter implements VenueAdapter {
   }
 
   async listActive(limit = 25): Promise<NormalizedMarket[]> {
-    const res = await fetch(`${LIMITLESS_BASE}/markets/active`);
+    const res = await fetch(`${LIMITLESS_BASE}/markets/active`, timed());
     if (!res.ok) throw new Error(`limitless listActive failed: ${res.status}`);
     const list = unwrap(await res.json());
     return list.slice(0, limit).map(toNormalized);

--- a/src/adapters/polymarket.ts
+++ b/src/adapters/polymarket.ts
@@ -6,6 +6,11 @@ import type {
 } from "../schema.js";
 
 const GAMMA_BASE = "https://gamma-api.polymarket.com";
+const FETCH_TIMEOUT_MS = 8000;
+
+function timed(): RequestInit {
+  return { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) };
+}
 
 interface GammaEvent {
   id: string;
@@ -194,7 +199,7 @@ export class PolymarketAdapter implements VenueAdapter {
     url.searchParams.set("order", "volume24hr");
     url.searchParams.set("ascending", "false");
 
-    const res = await fetch(url);
+    const res = await fetch(url, timed());
     if (!res.ok) throw new Error(`polymarket search failed: ${res.status}`);
     const json = (await res.json()) as GammaMarket[];
 
@@ -227,7 +232,7 @@ export class PolymarketAdapter implements VenueAdapter {
     const isNumericId = /^\d+$/.test(trimmed);
 
     if (isNumericId) {
-      const res = await fetch(`${GAMMA_BASE}/markets/${trimmed}`);
+      const res = await fetch(`${GAMMA_BASE}/markets/${trimmed}`, timed());
       if (res.status === 404) return null;
       if (!res.ok) throw new Error(`polymarket getMarket failed: ${res.status}`);
       const json = (await res.json()) as GammaMarket;
@@ -238,7 +243,7 @@ export class PolymarketAdapter implements VenueAdapter {
     const url = new URL(`${GAMMA_BASE}/markets`);
     url.searchParams.set("slug", trimmed);
     url.searchParams.set("limit", "1");
-    const res = await fetch(url);
+    const res = await fetch(url, timed());
     if (!res.ok) throw new Error(`polymarket getMarket-by-slug failed: ${res.status}`);
     const json = (await res.json()) as GammaMarket[];
     if (Array.isArray(json) && json.length > 0) return toNormalized(json[0]!);
@@ -247,7 +252,7 @@ export class PolymarketAdapter implements VenueAdapter {
     const search = new URL(`${GAMMA_BASE}/markets`);
     search.searchParams.set("q", trimmed.replace(/-/g, " "));
     search.searchParams.set("limit", "1");
-    const sr = await fetch(search);
+    const sr = await fetch(search, timed());
     if (!sr.ok) return null;
     const sj = (await sr.json()) as GammaMarket[];
     if (Array.isArray(sj) && sj.length > 0) return toNormalized(sj[0]!);
@@ -263,7 +268,7 @@ export class PolymarketAdapter implements VenueAdapter {
     url.searchParams.set("order", "volume24hr");
     url.searchParams.set("ascending", "false");
 
-    const res = await fetch(url);
+    const res = await fetch(url, timed());
     if (!res.ok) throw new Error(`polymarket listActive failed: ${res.status}`);
     const json = (await res.json()) as GammaMarket[];
     return json.slice(0, limit).map(toNormalized);
@@ -276,7 +281,7 @@ export class PolymarketAdapter implements VenueAdapter {
       const url = new URL(`${GAMMA_BASE}/markets`);
       url.searchParams.set("limit", "100");
       url.searchParams.set("q", q);
-      const res = await fetch(url);
+      const res = await fetch(url, timed());
       if (!res.ok) continue;
       const json = (await res.json()) as GammaMarket[];
       for (const raw of json) {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -184,20 +184,31 @@ function resolveMarketRef(input: string): { venue: NormalizedMarket["venue"]; id
   return null;
 }
 
-export async function runTool(name: string, args: unknown, env: ToolEnv = {}): Promise<unknown> {
+export interface ToolResult {
+  value: unknown;
+  // Per MCP spec: isError flags tool-level (semantic) failure to the client,
+  // distinct from JSON-RPC transport errors. Agents see this and know to
+  // surface or self-correct rather than treat the response as success.
+  isError?: boolean;
+}
+
+const ok = (value: unknown): ToolResult => ({ value });
+const err = (value: unknown): ToolResult => ({ value, isError: true });
+
+export async function runTool(name: string, args: unknown, env: ToolEnv = {}): Promise<ToolResult> {
   if (name === "pm_discover") {
     const { hypothesis, jurisdiction, limit_per_venue } = DiscoverInputSchema.parse(args);
-    return discover(hypothesis, jurisdiction, limit_per_venue);
+    return ok(await discover(hypothesis, jurisdiction, limit_per_venue));
   }
   if (name === "pm_recommend") {
     const { profile_url, jurisdiction, max_recommendations } = RecommendInputSchema.parse(args);
-    return recommendFromUrl(profile_url, jurisdiction, max_recommendations, env);
+    return ok(await recommendFromUrl(profile_url, jurisdiction, max_recommendations, env));
   }
   if (name === "pm_quote") {
     const { market } = QuoteInputSchema.parse(args);
     const ref = resolveMarketRef(market);
     if (!ref) {
-      return {
+      return err({
         error: "could_not_parse_market_ref",
         input: market,
         accepted_forms: [
@@ -206,32 +217,32 @@ export async function runTool(name: string, args: unknown, env: ToolEnv = {}): P
           "kalshi.com URL",
           "limitless.exchange URL",
         ],
-      };
+      });
     }
     const adapter = ADAPTERS.find((a) => a.venue === ref.venue);
-    if (!adapter) return { error: "unknown_venue", venue: ref.venue };
+    if (!adapter) return err({ error: "unknown_venue", venue: ref.venue });
     const m = await adapter.getMarket(ref.id);
-    if (!m) return { error: "market_not_found", venue: ref.venue, id: ref.id };
-    return { quote: m };
+    if (!m) return err({ error: "market_not_found", venue: ref.venue, id: ref.id });
+    return ok({ quote: m });
   }
   if (name === "pm_disputes_active") {
     const { limit } = DisputesActiveInputSchema.parse(args);
     const adapter = ADAPTERS.find((a) => a.venue === "polymarket");
     const polymarket = adapter as PolymarketAdapter | undefined;
     if (!polymarket || typeof polymarket.listDisputed !== "function") {
-      return { count: 0, markets: [], note: "no adapter exposes dispute listing" };
+      return ok({ count: 0, markets: [], note: "no adapter exposes dispute listing" });
     }
     const markets = await polymarket.listDisputed(limit);
-    return {
+    return ok({
       count: markets.length,
       note: "Polymarket UMA-flagged markets only. Kalshi and Limitless settle deterministically and have no analogous dispute risk.",
       markets,
-    };
+    });
   }
   if (name === "pm_search") {
     const { query, limit_per_venue, venues } = SearchInputSchema.parse(args);
     const out = await fanOutSearch(query, limit_per_venue, venues);
-    return { query, count: out.markets.length, errors: out.errors, markets: out.markets };
+    return ok({ query, count: out.markets.length, errors: out.errors, markets: out.markets });
   }
   if (name === "pm_list_active") {
     const { limit_per_venue, venues } = ListActiveInputSchema.parse(args);
@@ -248,7 +259,7 @@ export async function runTool(name: string, args: unknown, env: ToolEnv = {}): P
       if (r.status === "fulfilled") markets.push(...r.value);
       else errors.push({ venue, error: String(r.reason) });
     });
-    return { count: markets.length, errors, markets };
+    return ok({ count: markets.length, errors, markets });
   }
   throw new Error(`unknown tool: ${name}`);
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { z } from "zod";
 import { TOOL_DEFS, runTool } from "./tools.js";
 import { LANDING_HTML } from "./landing.js";
 
@@ -31,7 +32,7 @@ app.get("/", (c) =>
 app.get("/info", (c) =>
   c.json({
     name: "allbets-mcp",
-    version: "0.1.1",
+    version: "0.1.7",
     description:
       "Cross-venue prediction-market discovery. Tells your agent what bet exists across Polymarket, Kalshi, and Limitless and where to place it.",
     mcp_endpoint: "/mcp",
@@ -84,15 +85,22 @@ app.post("/mcp", async (c) => {
         const params = body.params ?? {};
         const name = params.name as string;
         const args = (params.arguments as Record<string, unknown>) ?? {};
-        const result = await runTool(name, args, c.env);
+        const { value, isError } = await runTool(name, args, c.env);
         return respond({
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(value, null, 2) }],
+          isError,
         });
       }
       default:
         return fail(-32601, `Method not found: ${body.method}`);
     }
   } catch (err) {
+    // Per JSON-RPC 2.0: -32602 for invalid params (Zod validation), -32603 for
+    // internal errors. MCP clients (Claude Desktop, etc.) surface these
+    // distinctly to the agent so it can self-correct invalid arguments.
+    if (err instanceof z.ZodError) {
+      return fail(-32602, "Invalid params", err.errors);
+    }
     return fail(-32603, err instanceof Error ? err.message : String(err));
   }
 });


### PR DESCRIPTION
## Summary

Cherry-picks the 3 still-relevant additive changes from **PR #7** (`feat/v0.1.3-adapter-hardening`) onto current `init`. Drops the 2 superseded ones (Kalshi rewrite, Limitless `AUTO_TITLE_PATTERN` — both already delivered in v0.1.4 / v0.1.6 with stronger implementations).

Closes #7.

## What's in

### 1. Adapter timeouts (all three venues)

`FETCH_TIMEOUT_MS = 8000` via `AbortSignal.timeout(...)`. `timed()` helper applied to every `fetch()` call in `src/adapters/{polymarket,kalshi,limitless}.ts`.

Before: any fetch could hang indefinitely. A slow Limitless or Kalshi response would block the whole `pm_discover` fan-out on the slowest leg.

After: 8-second hard cap per fetch. `Promise.allSettled` in fan-out paths means a single timeout shows as a per-venue error, not a whole-call failure.

### 2. Tool result semantics — `ToolResult { value, isError? }`

Per MCP spec, `tools/call` responses can carry `isError: true` to flag tool-level (semantic) failures distinct from JSON-RPC transport errors. Agents see this and know to self-correct rather than treating "response with error field" as success.

`runTool` now returns `ToolResult` with `ok()` / `err()` helpers. Semantic failures flagged:
- `pm_quote` → `could_not_parse_market_ref`
- `pm_quote` → `unknown_venue`
- `pm_quote` → `market_not_found`

`src/worker.ts` JSON-RPC dispatcher unwraps `ToolResult` and propagates `isError` in the `tools/call` response.

### 3. JSON-RPC error code distinction

- `z.ZodError` → `-32602 "Invalid params"` (was: generic `-32603`)
- Other thrown errors → `-32603 "Internal error"` with `data` carrying the validation issues

MCP clients (Claude Desktop, Cursor) surface these distinctly so the agent can self-correct invalid arguments.

### 4. Version stamps

`0.1.1` → `0.1.7` in `package.json`, `worker.ts /info`, and `initialize`'s `serverInfo`.

## What I dropped from PR #7

| Change | Status |
|---|---|
| Kalshi `/events?with_nested_markets=true` rewrite | **Superseded.** Current adapter already uses `/events` PLUS `/series`-aware fetch (more sophisticated). |
| Limitless `AUTO_TITLE_PATTERN` regex | **Superseded.** Current adapter already has 3-signal `isAutoGenerated()` (tags + automationType + title regex). |

## Smoke test

```
pm_quote("not-a-real-market-id") → isError: true, returned as red error in MCP client
pm_quote("polymarket:906973")    → success, full quote
pm_discover("Fed cut rates June") → all 3 venues respond within 8s budget
```

## Notes

- Branch base: `init`.
- Live deploy already up at `allbets.dev/mcp` (deployed pre-merge for verification).
