### PR TITLE
feat(v0.2.1): visual-mode — per-call OpenAI image generation per market (closes #17)

### DIFF
--- a/src/imagen.ts
+++ b/src/imagen.ts
@@ -1,0 +1,109 @@
+import type { NormalizedMarket } from "./schema.js";
+
+export interface ImagenResult {
+  image_url?: string;
+  image_prompt?: string;
+  warning?: string;
+}
+
+const OPENAI_BASE = "https://api.openai.com/v1";
+const MODEL = "gpt-image-1";
+const SIZE = "1024x1024";
+const TIMEOUT_MS = 25000;
+
+function buildPrompt(market: NormalizedMarket): string {
+  const yesProb =
+    market.outcomes.find((o) => /yes/i.test(o.label))?.probability ?? 0.5;
+  const yesPct = Math.round(yesProb * 100);
+  const ev = market.event_question ?? market.question;
+  const safeQ = market.question.replace(/["\\]/g, "");
+  return [
+    `Editorial illustration for a prediction market.`,
+    `Question: "${safeQ}".`,
+    ev !== market.question ? `Event context: "${ev.replace(/["\\]/g, "")}".` : "",
+    `Current market consensus: ${yesPct}% YES.`,
+    `Style: clean editorial illustration, muted palette, single focal subject, magazine-spread feel.`,
+    `Constraints: no text overlay, no charts, no logos, no UI screenshots, no AI-slop aesthetics, no purple gradients.`,
+    `Tone matches the question subject: serious for politics or finance, playful for sports or pop culture.`,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+export async function generateMarketImage(
+  market: NormalizedMarket,
+  apiKey: string,
+): Promise<ImagenResult> {
+  const prompt = buildPrompt(market);
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(`${OPENAI_BASE}/images/generations`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        prompt,
+        n: 1,
+        size: SIZE,
+      }),
+      signal: ctrl.signal,
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      return {
+        image_prompt: prompt,
+        warning: `openai images ${res.status}: ${body.slice(0, 200)}`,
+      };
+    }
+    const json = (await res.json()) as {
+      data?: Array<{ url?: string; b64_json?: string }>;
+    };
+    const url = json.data?.[0]?.url;
+    if (!url) {
+      return { image_prompt: prompt, warning: "openai response missing data[0].url" };
+    }
+    return { image_url: url, image_prompt: prompt };
+  } catch (err) {
+    return {
+      image_prompt: prompt,
+      warning: `openai images failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+export async function decorateWithImages(
+  markets: NormalizedMarket[],
+  apiKey: string | undefined,
+  enabled: boolean,
+): Promise<{ markets: NormalizedMarket[]; warnings: string[] }> {
+  const warnings: string[] = [];
+  if (!enabled) return { markets, warnings };
+  if (!apiKey) {
+    warnings.push("visual:true requested but OPENAI_API_KEY not configured on Worker");
+    return { markets, warnings };
+  }
+  const settled = await Promise.allSettled(
+    markets.map((m) => generateMarketImage(m, apiKey)),
+  );
+  const out = markets.map((m, i) => {
+    const r = settled[i];
+    if (!r) return m;
+    if (r.status === "rejected") {
+      warnings.push(`image gen rejected for ${m.venue}:${m.venue_market_id}: ${String(r.reason).slice(0, 120)}`);
+      return m;
+    }
+    if (r.value.warning) warnings.push(r.value.warning);
+    return {
+      ...m,
+      image_url: r.value.image_url,
+      image_prompt: r.value.image_prompt,
+    };
+  });
+  return { markets: out, warnings };
+}

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -71,6 +71,8 @@ export const NormalizedMarketSchema = z.object({
   raw_url: z.string().url().optional(),
   is_affiliate_link: z.boolean().optional(),
   affiliate_disclosure: z.string().optional(),
+  image_url: z.string().url().optional(),
+  image_prompt: z.string().optional(),
   raw: z.unknown().optional(),
 });
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -3,6 +3,7 @@ import { ADAPTERS, discover, fanOutSearch } from "./discovery.js";
 import { PolymarketAdapter } from "./adapters/polymarket.js";
 import { recommendFromUrl } from "./recommend.js";
 import { decorateMarket, decorateMarkets, type AffiliateConfig } from "./affiliate.js";
+import { decorateWithImages } from "./imagen.js";
 import type { NormalizedMarket } from "./schema.js";
 
 interface WorkersAIBinding {
@@ -18,6 +19,7 @@ interface ToolEnv {
   FIRECRAWL_API_KEY?: string;
   ANTHROPIC_API_KEY?: string;
   EXA_API_KEY?: string;
+  OPENAI_API_KEY?: string;
   POLYMARKET_REF_CODE?: string;
   KALSHI_REF_CODE?: string;
   LIMITLESS_REF_CODE?: string;
@@ -41,31 +43,37 @@ export const DiscoverInputSchema = z.object({
   hypothesis: z.string().min(2),
   jurisdiction: z.enum(["us", "non_us", "unknown"]).default("unknown"),
   limit_per_venue: z.number().int().positive().max(30).default(15),
+  visual: z.boolean().default(false),
 });
 
 export const SearchInputSchema = z.object({
   query: z.string().min(2),
   limit_per_venue: z.number().int().positive().max(50).default(10),
   venues: VenueArgSchema,
+  visual: z.boolean().default(false),
 });
 
 export const ListActiveInputSchema = z.object({
   limit_per_venue: z.number().int().positive().max(50).default(10),
   venues: VenueArgSchema,
+  visual: z.boolean().default(false),
 });
 
 export const QuoteInputSchema = z.object({
   market: z.string().min(1),
+  visual: z.boolean().default(false),
 });
 
 export const DisputesActiveInputSchema = z.object({
   limit: z.number().int().positive().max(50).default(20),
+  visual: z.boolean().default(false),
 });
 
 export const RecommendInputSchema = z.object({
   profile_url: z.string().url(),
   jurisdiction: z.enum(["us", "non_us", "unknown"]).default("unknown"),
   max_recommendations: z.number().int().positive().max(20).default(10),
+  visual: z.boolean().default(false),
 });
 
 export const TOOL_DEFS = [
@@ -84,6 +92,7 @@ export const TOOL_DEFS = [
           description: "User's regulatory jurisdiction. US blocks Polymarket-international; non-US blocks Kalshi.",
         },
         limit_per_venue: { type: "number", default: 15 },
+        visual: { type: "boolean", default: false, description: "If true, attach an OpenAI-generated editorial image to each market in the response. Requires OPENAI_API_KEY Worker secret. Costs ~$0.04 per image." },
       },
       required: ["hypothesis"],
     },
@@ -247,14 +256,32 @@ export async function runTool(name: string, args: unknown, env: ToolEnv = {}): P
   const affiliateConfig = affiliateConfigFromEnv(env);
 
   if (name === "pm_discover") {
-    const { hypothesis, jurisdiction, limit_per_venue } = DiscoverInputSchema.parse(args);
+    const { hypothesis, jurisdiction, limit_per_venue, visual } = DiscoverInputSchema.parse(args);
     const report = await discover(hypothesis, jurisdiction, limit_per_venue);
-    return ok(decorateDiscoverReport(report, affiliateConfig));
+    let decorated = decorateDiscoverReport(report, affiliateConfig);
+    if (visual) {
+      const allMarkets: NormalizedMarket[] = [];
+      decorated.per_venue.forEach((v) => {
+        if (v.best_match) allMarkets.push(v.best_match);
+      });
+      const { markets: withImages, warnings } = await decorateWithImages(allMarkets, env.OPENAI_API_KEY, true);
+      const imageByKey = new Map<string, NormalizedMarket>();
+      withImages.forEach((m) => imageByKey.set(`${m.venue}:${m.venue_market_id}`, m));
+      decorated = {
+        ...decorated,
+        per_venue: decorated.per_venue.map((v) => {
+          if (!v.best_match) return v;
+          const enriched = imageByKey.get(`${v.best_match.venue}:${v.best_match.venue_market_id}`);
+          return enriched ? { ...v, best_match: enriched } : v;
+        }),
+      } as typeof decorated;
+      if (warnings.length > 0) (decorated as typeof decorated & { warnings?: string[] }).warnings = warnings;
+    }
+    return ok(decorated);
   }
   if (name === "pm_recommend") {
-    const { profile_url, jurisdiction, max_recommendations } = RecommendInputSchema.parse(args);
-    // Dispatch to RecommendAgent (Cloudflare Agents SDK Durable Object) — owns
-    // the URL→recommendations pipeline with persisted state across calls.
+    const { profile_url, jurisdiction, max_recommendations, visual } = RecommendInputSchema.parse(args);
+    let result: { recommendations: Array<{ market: NormalizedMarket; [key: string]: unknown }>; [key: string]: unknown };
     if (env.RecommendAgent) {
       const id = env.RecommendAgent.idFromName("pm_recommend:default");
       const stub = env.RecommendAgent.get(id);
@@ -269,21 +296,33 @@ export async function runTool(name: string, args: unknown, env: ToolEnv = {}): P
         const text = await agentRes.text();
         return err({ error: "agent_failed", status: agentRes.status, detail: text.slice(0, 500) });
       }
-      return ok(await agentRes.json());
+      result = (await agentRes.json()) as typeof result;
+    } else {
+      const report = await recommendFromUrl(profile_url, jurisdiction, max_recommendations, env);
+      result = {
+        ...report,
+        recommendations: report.recommendations.map((rec) => ({
+          ...rec,
+          market: decorateMarket(rec.market, affiliateConfig),
+        })),
+      };
     }
-    // Fallback: pre-Agents-SDK path (in case DO binding is missing in dev)
-    const report = await recommendFromUrl(profile_url, jurisdiction, max_recommendations, env);
-    const decorated = {
-      ...report,
-      recommendations: report.recommendations.map((rec) => ({
-        ...rec,
-        market: decorateMarket(rec.market, affiliateConfig),
-      })),
-    };
-    return ok(decorated);
+    if (visual) {
+      const markets = result.recommendations.map((r) => r.market);
+      const { markets: withImages, warnings } = await decorateWithImages(markets, env.OPENAI_API_KEY, true);
+      result = {
+        ...result,
+        recommendations: result.recommendations.map((rec, i) => ({
+          ...rec,
+          market: withImages[i] ?? rec.market,
+        })),
+      };
+      if (warnings.length > 0) (result as { warnings?: string[] }).warnings = warnings;
+    }
+    return ok(result);
   }
   if (name === "pm_quote") {
-    const { market } = QuoteInputSchema.parse(args);
+    const { market, visual } = QuoteInputSchema.parse(args);
     const ref = resolveMarketRef(market);
     if (!ref) {
       return err({
@@ -301,7 +340,14 @@ export async function runTool(name: string, args: unknown, env: ToolEnv = {}): P
     if (!adapter) return err({ error: "unknown_venue", venue: ref.venue });
     const m = await adapter.getMarket(ref.id);
     if (!m) return err({ error: "market_not_found", venue: ref.venue, id: ref.id });
-    return ok({ quote: decorateMarket(m, affiliateConfig) });
+    let decorated = decorateMarket(m, affiliateConfig);
+    const warnings: string[] = [];
+    if (visual) {
+      const result = await decorateWithImages([decorated], env.OPENAI_API_KEY, true);
+      decorated = result.markets[0] ?? decorated;
+      warnings.push(...result.warnings);
+    }
+    return ok(warnings.length > 0 ? { quote: decorated, warnings } : { quote: decorated });
   }
   if (name === "pm_disputes_active") {
     const { limit } = DisputesActiveInputSchema.parse(args);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -30,6 +30,7 @@ interface WorkerEnv {
   POLYMARKET_REF_CODE?: string;
   KALSHI_REF_CODE?: string;
   LIMITLESS_REF_CODE?: string;
+  OPENAI_API_KEY?: string;
   AI?: WorkersAIBinding;
   RecommendAgent?: DurableObjectNamespace;
 }


### PR DESCRIPTION
Adds `visual: true` opt-in flag to pm_discover, pm_quote, pm_recommend. Generates 1024x1024 editorial illustration per market via OpenAI gpt-image-1. Two-layer cost control: per-call opt-in + OPENAI_API_KEY Worker secret gate. Remove the secret post-demo to fully disable. ~$0.04 per image. Smoke-tested deferred to post-key-injection. Closes #17.