### PR TITLE
feat(v0.1.10): pm_history rebased from #15 + Kalshi 404 fix + ToolResult wrapping

### DIFF
--- a/src/adapters/history-util.ts
+++ b/src/adapters/history-util.ts
@@ -1,0 +1,52 @@
+import type { HistoryPoint, HistoryRange, HistoryStats } from "../schema.js";
+
+export interface HistoryWindow {
+  start_seconds: number;
+  end_seconds: number;
+  resolution_minutes: number;
+}
+
+// Map a user-facing range to a (window, bucket-size) pair tuned to keep point
+// counts in the 24-60 range. LLMs digest that cleanly; finer buckets balloon
+// token usage without surfacing more signal.
+export function rangeToWindow(range: HistoryRange): HistoryWindow {
+  const now = Math.floor(Date.now() / 1000);
+  switch (range) {
+    case "1h":
+      return { start_seconds: now - 60 * 60, end_seconds: now, resolution_minutes: 1 };
+    case "24h":
+      return { start_seconds: now - 24 * 60 * 60, end_seconds: now, resolution_minutes: 60 };
+    case "7d":
+      return { start_seconds: now - 7 * 24 * 60 * 60, end_seconds: now, resolution_minutes: 360 };
+    case "30d":
+      return { start_seconds: now - 30 * 24 * 60 * 60, end_seconds: now, resolution_minutes: 1440 };
+    case "all":
+      return { start_seconds: 0, end_seconds: now, resolution_minutes: 1440 };
+  }
+}
+
+export function summarizeSeries(series: HistoryPoint[]): HistoryStats | null {
+  if (series.length === 0) return null;
+  const open = series[0]!.price_yes;
+  const close = series[series.length - 1]!.price_yes;
+  let high = open;
+  let low = open;
+  let volume_total: number | undefined;
+  for (const p of series) {
+    if (p.price_yes > high) high = p.price_yes;
+    if (p.price_yes < low) low = p.price_yes;
+    if (p.volume_usd !== undefined) {
+      volume_total = (volume_total ?? 0) + p.volume_usd;
+    }
+  }
+  const change_pct = open === 0 ? 0 : ((close - open) / open) * 100;
+  return {
+    open,
+    close,
+    high,
+    low,
+    change_pct: Math.round(change_pct * 100) / 100,
+    samples: series.length,
+    ...(volume_total !== undefined ? { volume_total_usd: Math.round(volume_total * 100) / 100 } : {}),
+  };
+}

--- a/src/adapters/kalshi.ts
+++ b/src/adapters/kalshi.ts
@@ -1,5 +1,12 @@
 import type { VenueAdapter } from "./types.js";
-import type { NormalizedMarket, ResolutionStatus } from "../schema.js";
+import type {
+  HistoryPoint,
+  HistoryRange,
+  MarketHistory,
+  NormalizedMarket,
+  ResolutionStatus,
+} from "../schema.js";
+import { rangeToWindow, summarizeSeries } from "./history-util.js";
 
 const KALSHI_BASE = "https://api.elections.kalshi.com/trade-api/v2";
 const FETCH_TIMEOUT_MS = 8000;
@@ -263,5 +270,78 @@ export class KalshiAdapter implements VenueAdapter {
     const events = await fetchEventsByCursor(200);
     const flat = flattenMarkets(events);
     return flat.slice(0, limit).map((x) => toNormalized(x.market, x.eventTitle));
+  }
+
+  // /series/{series_ticker}/markets/{ticker}/candlesticks returns OHLC + volume
+  // per period. series_ticker is the prefix-before-first-dash of the market
+  // ticker (e.g. KXNEWPOPE-70-PPIZ → series=KXNEWPOPE). Bare tickers without
+  // dashes don't have a series — fall back to empty-history with a note.
+  async getHistory(venueMarketId: string, range: HistoryRange): Promise<MarketHistory | null> {
+    const market = await this.getMarket(venueMarketId);
+    if (!market) return null;
+    const ticker = market.venue_market_id;
+    const window = rangeToWindow(range);
+    const seriesTicker = ticker.includes("-") ? ticker.split("-")[0] : null;
+    if (!seriesTicker) {
+      return {
+        market,
+        range,
+        resolution_minutes: window.resolution_minutes,
+        source_supports_history: false,
+        series: [],
+        stats: null,
+        note: `cannot derive kalshi series_ticker from market ticker '${ticker}' (no dash separator)`,
+      };
+    }
+    const url = new URL(
+      `${KALSHI_BASE}/series/${encodeURIComponent(seriesTicker)}/markets/${encodeURIComponent(ticker)}/candlesticks`,
+    );
+    url.searchParams.set("start_ts", String(window.start_seconds));
+    url.searchParams.set("end_ts", String(window.end_seconds));
+    url.searchParams.set("period_interval", String(window.resolution_minutes));
+
+    const res = await fetch(url, timed());
+    if (!res.ok) {
+      return {
+        market,
+        range,
+        resolution_minutes: window.resolution_minutes,
+        source_supports_history: false,
+        series: [],
+        stats: null,
+        note: `kalshi candlestick endpoint returned ${res.status} for series='${seriesTicker}', market='${ticker}' — series may not exist or this market may not have candlestick data`,
+      };
+    }
+    const json = (await res.json()) as {
+      candlesticks?: Array<{
+        end_period_ts: number;
+        volume_fp?: string | number;
+        price?: { previous_dollars?: string };
+        yes_bid?: { close_dollars?: string };
+        yes_ask?: { close_dollars?: string };
+      }>;
+    };
+    const series: HistoryPoint[] = (json.candlesticks ?? []).map((c) => {
+      const bid = Number(c.yes_bid?.close_dollars ?? "");
+      const ask = Number(c.yes_ask?.close_dollars ?? "");
+      let price = Number(c.price?.previous_dollars ?? "0");
+      if (Number.isFinite(bid) && Number.isFinite(ask) && bid > 0 && ask > 0) {
+        price = (bid + ask) / 2;
+      }
+      const vol = Number(c.volume_fp ?? "");
+      return {
+        ts: new Date(c.end_period_ts * 1000).toISOString(),
+        price_yes: Math.max(0, Math.min(1, price)),
+        ...(Number.isFinite(vol) && vol > 0 ? { volume_usd: vol } : {}),
+      };
+    });
+    return {
+      market,
+      range,
+      resolution_minutes: window.resolution_minutes,
+      source_supports_history: true,
+      series,
+      stats: summarizeSeries(series),
+    };
   }
 }

--- a/src/adapters/limitless.ts
+++ b/src/adapters/limitless.ts
@@ -1,5 +1,11 @@
 import type { VenueAdapter } from "./types.js";
-import type { NormalizedMarket, ResolutionStatus } from "../schema.js";
+import type {
+  HistoryRange,
+  MarketHistory,
+  NormalizedMarket,
+  ResolutionStatus,
+} from "../schema.js";
+import { rangeToWindow } from "./history-util.js";
 
 const LIMITLESS_BASE = "https://api.limitless.exchange";
 const FETCH_TIMEOUT_MS = 8000;
@@ -151,5 +157,23 @@ export class LimitlessAdapter implements VenueAdapter {
     if (!res.ok) throw new Error(`limitless listActive failed: ${res.status}`);
     const list = unwrap(await res.json());
     return list.slice(0, limit).map(toNormalized);
+  }
+
+  // Limitless does not currently expose price history via public API. Most of
+  // their volume is auto-generated 15-min/1h Pyth-tracking markets that recycle
+  // before any meaningful series accumulates. Return an honest empty result
+  // with the current snapshot so the agent can still reason about the market.
+  async getHistory(venueMarketId: string, range: HistoryRange): Promise<MarketHistory | null> {
+    const market = await this.getMarket(venueMarketId);
+    if (!market) return null;
+    return {
+      market,
+      range,
+      resolution_minutes: rangeToWindow(range).resolution_minutes,
+      source_supports_history: false,
+      series: [],
+      stats: null,
+      note: "limitless does not expose price history via public API. Most lumy-generated markets recycle every 15-60 min so historical series would be near-empty regardless. Use the current snapshot in `market` for decision context.",
+    };
   }
 }

--- a/src/adapters/polymarket.ts
+++ b/src/adapters/polymarket.ts
@@ -1,9 +1,13 @@
 import type { VenueAdapter } from "./types.js";
 import type {
+  HistoryPoint,
+  HistoryRange,
+  MarketHistory,
   NormalizedMarket,
   ResolutionStatus,
   SettlementRisk,
 } from "../schema.js";
+import { rangeToWindow, summarizeSeries } from "./history-util.js";
 
 const GAMMA_BASE = "https://gamma-api.polymarket.com";
 const FETCH_TIMEOUT_MS = 8000;
@@ -272,6 +276,58 @@ export class PolymarketAdapter implements VenueAdapter {
     if (!res.ok) throw new Error(`polymarket listActive failed: ${res.status}`);
     const json = (await res.json()) as GammaMarket[];
     return json.slice(0, limit).map(toNormalized);
+  }
+
+  // CLOB /prices-history takes a clobTokenId (the YES outcome's ERC-1155 id),
+  // not the Gamma market id. Resolve through getMarket() to get tradable_outcome_id,
+  // then ask CLOB for the price series.
+  async getHistory(venueMarketId: string, range: HistoryRange): Promise<MarketHistory | null> {
+    const market = await this.getMarket(venueMarketId);
+    if (!market) return null;
+    const yesTokenId = market.outcomes[0]?.tradable_outcome_id;
+    const window = rangeToWindow(range);
+    if (!yesTokenId) {
+      return {
+        market,
+        range,
+        resolution_minutes: window.resolution_minutes,
+        source_supports_history: false,
+        series: [],
+        stats: null,
+        note: "polymarket market is missing clobTokenIds — likely an event-aggregator entry, not a tradable market",
+      };
+    }
+    const url = new URL("https://clob.polymarket.com/prices-history");
+    url.searchParams.set("market", yesTokenId);
+    url.searchParams.set("startTs", String(window.start_seconds));
+    url.searchParams.set("endTs", String(window.end_seconds));
+    url.searchParams.set("fidelity", String(window.resolution_minutes));
+
+    const res = await fetch(url, timed());
+    if (!res.ok) {
+      return {
+        market,
+        range,
+        resolution_minutes: window.resolution_minutes,
+        source_supports_history: false,
+        series: [],
+        stats: null,
+        note: `polymarket prices-history returned ${res.status} for clobTokenId='${yesTokenId.slice(0, 12)}...'`,
+      };
+    }
+    const json = (await res.json()) as { history?: Array<{ t: number; p: number }> };
+    const series: HistoryPoint[] = (json.history ?? []).map((pt) => ({
+      ts: new Date(pt.t * 1000).toISOString(),
+      price_yes: pt.p,
+    }));
+    return {
+      market,
+      range,
+      resolution_minutes: window.resolution_minutes,
+      source_supports_history: true,
+      series,
+      stats: summarizeSeries(series),
+    };
   }
 
   async listDisputed(limit = 20): Promise<NormalizedMarket[]> {

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -1,4 +1,4 @@
-import type { NormalizedMarket } from "../schema.js";
+import type { HistoryRange, MarketHistory, NormalizedMarket } from "../schema.js";
 
 export interface VenueAdapter {
   venue: NormalizedMarket["venue"];
@@ -6,4 +6,5 @@ export interface VenueAdapter {
   getMarket(venueMarketId: string): Promise<NormalizedMarket | null>;
   listActive(limit?: number): Promise<NormalizedMarket[]>;
   listDisputed?(limit?: number): Promise<NormalizedMarket[]>;
+  getHistory?(venueMarketId: string, range: HistoryRange): Promise<MarketHistory | null>;
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -103,3 +103,35 @@ export const DiscoveryReportSchema = z.object({
 });
 
 export type DiscoveryReport = z.infer<typeof DiscoveryReportSchema>;
+
+export const HistoryRangeSchema = z.enum(["1h", "24h", "7d", "30d", "all"]);
+export type HistoryRange = z.infer<typeof HistoryRangeSchema>;
+
+export const HistoryPointSchema = z.object({
+  ts: z.string(),
+  price_yes: z.number().min(0).max(1),
+  volume_usd: z.number().nonnegative().optional(),
+});
+export type HistoryPoint = z.infer<typeof HistoryPointSchema>;
+
+export const HistoryStatsSchema = z.object({
+  open: z.number().min(0).max(1),
+  close: z.number().min(0).max(1),
+  high: z.number().min(0).max(1),
+  low: z.number().min(0).max(1),
+  change_pct: z.number(),
+  samples: z.number().int().nonnegative(),
+  volume_total_usd: z.number().nonnegative().optional(),
+});
+export type HistoryStats = z.infer<typeof HistoryStatsSchema>;
+
+export const MarketHistorySchema = z.object({
+  market: NormalizedMarketSchema,
+  range: HistoryRangeSchema,
+  resolution_minutes: z.number().int().positive(),
+  source_supports_history: z.boolean(),
+  series: z.array(HistoryPointSchema),
+  stats: HistoryStatsSchema.nullable(),
+  note: z.string().optional(),
+});
+export type MarketHistory = z.infer<typeof MarketHistorySchema>;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -4,6 +4,7 @@ import { PolymarketAdapter } from "./adapters/polymarket.js";
 import { recommendFromUrl } from "./recommend.js";
 import { decorateMarket, decorateMarkets, type AffiliateConfig } from "./affiliate.js";
 import { decorateWithImages } from "./imagen.js";
+import { HistoryRangeSchema } from "./schema.js";
 import type { NormalizedMarket } from "./schema.js";
 
 interface WorkersAIBinding {
@@ -76,6 +77,11 @@ export const RecommendInputSchema = z.object({
   visual: z.boolean().default(false),
 });
 
+export const HistoryInputSchema = z.object({
+  market: z.string().min(1),
+  range: HistoryRangeSchema.default("24h"),
+});
+
 export const TOOL_DEFS = [
   {
     name: "pm_discover",
@@ -107,6 +113,27 @@ export const TOOL_DEFS = [
         market: {
           type: "string",
           description: "Market URL or 'venue:id' shorthand. Examples: 'https://polymarket.com/event/...', 'polymarket:540816', 'kalshi:KXFEDMTG-26JUN-T5', 'limitless:0x...'",
+        },
+      },
+      required: ["market"],
+    },
+  },
+  {
+    name: "pm_history",
+    description:
+      "Price + volume time series for a single market. Pass the same `market` shape pm_quote accepts (URL or 'venue:id'). Returns the current normalized market plus a series of {ts, price_yes, volume_usd?} buckets and OHLC stats (open/close/high/low/change_pct). Use this to detect 'this market moved against me overnight' or 'this market just spiked' — the trust-shape badge is a snapshot, this is the trajectory behind it. Polymarket + Kalshi supported; Limitless returns an honest empty result with the current snapshot since their public API does not expose history.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        market: {
+          type: "string",
+          description: "Market URL or 'venue:id' shorthand (same forms pm_quote accepts).",
+        },
+        range: {
+          type: "string",
+          enum: ["1h", "24h", "7d", "30d", "all"],
+          default: "24h",
+          description: "Time window. Bucket size is auto-tuned to keep the series in the 24-60 point range so it stays LLM-digestible.",
         },
       },
       required: ["market"],
@@ -348,6 +375,30 @@ export async function runTool(name: string, args: unknown, env: ToolEnv = {}): P
       warnings.push(...result.warnings);
     }
     return ok(warnings.length > 0 ? { quote: decorated, warnings } : { quote: decorated });
+  }
+  if (name === "pm_history") {
+    const { market, range } = HistoryInputSchema.parse(args);
+    const ref = resolveMarketRef(market);
+    if (!ref) {
+      return err({
+        error: "could_not_parse_market_ref",
+        input: market,
+        accepted_forms: [
+          "venue:id (e.g. 'polymarket:540816', 'kalshi:KXFEDMTG-26JUN-T5')",
+          "polymarket.com URL",
+          "kalshi.com URL",
+          "limitless.exchange URL",
+        ],
+      });
+    }
+    const adapter = ADAPTERS.find((a) => a.venue === ref.venue);
+    if (!adapter) return err({ error: "unknown_venue", venue: ref.venue });
+    if (typeof adapter.getHistory !== "function") {
+      return err({ error: "history_not_implemented_for_venue", venue: ref.venue });
+    }
+    const result = await adapter.getHistory(ref.id, range);
+    if (!result) return err({ error: "market_not_found", venue: ref.venue, id: ref.id });
+    return ok(result);
   }
   if (name === "pm_disputes_active") {
     const { limit } = DisputesActiveInputSchema.parse(args);


### PR DESCRIPTION
Cherry-picks Marc's `pm_history` from #15 onto current init. Reconciles with v0.1.7 (timeouts + ToolResult), v0.1.9 (affiliate fields), v0.2.0 (CF Agents SDK), v0.2.1 (visual-mode image fields).

**Marc's design kept verbatim:**
- `src/adapters/history-util.ts` — rangeToWindow + summarizeSeries
- Polymarket CLOB /prices-history via clobTokenId
- Kalshi /series/{series_ticker}/markets/{ticker}/candlesticks with prefix-before-dash derivation
- Limitless honest-empty + explanatory note

**Reconciliation on top:**

1. **Adapter timeouts** — every new fetch wrapped via the existing `timed()` helper (8s AbortSignal)
2. **ToolResult.isError wrapping** — `pm_history` returns now wrapped: `ok(result)` for success, `err({...})` for parse-fail / unknown-venue / history-not-implemented / market-not-found
3. **Kalshi 404 graceful fallback** — Marc's review-flagged bug. The candlestick endpoint would throw on non-200, propagating as JSON-RPC -32603. Now catches + returns empty-history with explanatory note (same pattern as Limitless).
4. **Kalshi bare-ticker handling** — tickers without dashes can't derive a series_ticker. Now check for dash presence, return empty-history with note instead of throwing.
5. **Polymarket prices-history defensive fallback** — same pattern, catches non-200 (CLOB can return errors for new markets without accumulated data).
6. **Schema additions** — Marc's HistoryRange/HistoryPoint/HistoryStats/MarketHistory unchanged. MarketHistory embeds NormalizedMarket which now carries v0.1.9 affiliate + v0.2.1 image fields automatically.

**Closes #15.** Tested live on `allbets.dev/mcp`.