### PR TITLE
fix: expose 'visual' arg in tool inputSchemas (was missed during PR #20 squash)

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -106,7 +106,7 @@ export const TOOL_DEFS = [
   {
     name: "pm_quote",
     description:
-      "Single-market deep-dive. Pass a market URL (Polymarket / Kalshi / Limitless) or a 'venue:id' shorthand (e.g. 'polymarket:540816' or 'kalshi:KXFEDMTG-26JUN-T5'). Returns the fully-loaded normalized market including settlement risk badge (UMA dispute window, bond/reward, resolution status). Use this AFTER pm_discover to get the trust shape behind a price.",
+      "Single-market deep-dive. Pass a market URL (Polymarket / Kalshi / Limitless) or a 'venue:id' shorthand (e.g. 'polymarket:540816' or 'kalshi:KXFEDMTG-26JUN-T5'). Returns the fully-loaded normalized market including settlement risk badge (UMA dispute window, bond/reward, resolution status). Use this AFTER pm_discover to get the trust shape behind a price. Pass visual=true to attach an OpenAI-generated illustration to the response.",
     inputSchema: {
       type: "object",
       properties: {
@@ -114,6 +114,7 @@ export const TOOL_DEFS = [
           type: "string",
           description: "Market URL or 'venue:id' shorthand. Examples: 'https://polymarket.com/event/...', 'polymarket:540816', 'kalshi:KXFEDMTG-26JUN-T5', 'limitless:0x...'",
         },
+        visual: { type: "boolean", default: false, description: "If true, attach an OpenAI-generated editorial image to the market in the response. Requires OPENAI_API_KEY Worker secret. Costs ~$0.04 per image." },
       },
       required: ["market"],
     },
@@ -153,7 +154,7 @@ export const TOOL_DEFS = [
   {
     name: "pm_recommend",
     description:
-      "Personalized recommendations via the RecommendAgent (Cloudflare Agents SDK Durable Object). Scrape a profile URL (blog, Substack, personal site), extract topics + stances via Workers AI, return up to N prediction-market bets across Polymarket / Kalshi / Limitless ranked by stance-alignment + liquidity. The agent persists call history in SQLite at the edge; no PII is stored.",
+      "Personalized recommendations via the RecommendAgent (Cloudflare Agents SDK Durable Object). Scrape a profile URL (blog, Substack, personal site), extract topics + stances via Workers AI, return up to N prediction-market bets across Polymarket / Kalshi / Limitless ranked by stance-alignment + liquidity. The agent persists call history in SQLite at the edge; no PII is stored. Pass visual=true to attach an OpenAI-generated illustration to each recommendation.",
     inputSchema: {
       type: "object",
       properties: {
@@ -167,6 +168,7 @@ export const TOOL_DEFS = [
           default: "unknown",
         },
         max_recommendations: { type: "number", default: 10 },
+        visual: { type: "boolean", default: false, description: "If true, attach an OpenAI-generated editorial image to each recommended market. Requires OPENAI_API_KEY Worker secret. Costs ~$0.04 per image." },
       },
       required: ["profile_url"],
     },
@@ -180,6 +182,7 @@ export const TOOL_DEFS = [
         query: { type: "string" },
         limit_per_venue: { type: "number", default: 10 },
         venues: { type: "array", items: { enum: ["polymarket", "kalshi", "limitless"] } },
+        visual: { type: "boolean", default: false },
       },
       required: ["query"],
     },
@@ -192,6 +195,7 @@ export const TOOL_DEFS = [
       properties: {
         limit_per_venue: { type: "number", default: 10 },
         venues: { type: "array", items: { enum: ["polymarket", "kalshi", "limitless"] } },
+        visual: { type: "boolean", default: false },
       },
     },
   },


### PR DESCRIPTION
Visual-mode bug: the 'visual' property was in the Zod input schemas but missing from the JSON Schema 'inputSchema' declarations sent to MCP clients. Without it, Claude Desktop dropped 'visual:true' before sending. This fix was committed on the v0.1.10 branch but landed AFTER the squash-merge, so PR #20 didn't capture it. Cherry-picked here. Live on allbets.dev/mcp.