### PR TITLE
feat(v0.1.13): pm_signal — live X signal via Grok (rebased from #19)

### DIFF
--- a/src/grok.ts
+++ b/src/grok.ts
@@ -1,0 +1,176 @@
+// Grok / xAI live X (Twitter) signal adapter.
+//
+// Uses the xAI Responses API (POST /v1/responses) with the built-in `x_search`
+// agent tool to pull recent posts about a topic with citation URLs. This is
+// xAI's first-party access to the X firehose — Claude / GPT / Gemini all
+// require scraping (which X actively blocks) so Grok is the durable choice
+// for this signal source.
+//
+// Note re: best_practices.md "Sampling": that guidance says prefer client-side
+// LLM access via MCP sampling (no server-side API key). We accept the tradeoff
+// here because the actual product is X.com firehose access, not the LLM
+// reasoning — and only Grok provides the firehose.
+
+const XAI_RESPONSES_URL = "https://api.x.ai/v1/responses";
+const FETCH_TIMEOUT_MS = 30_000; // x_search internally makes multiple searches
+
+export interface SignalPost {
+  handle?: string;
+  text: string;
+  posted_at?: string;
+  url?: string;
+  retweets_estimate?: number;
+  likes_estimate?: number;
+}
+
+export interface SignalResult {
+  query: string;
+  hours_back: number;
+  source: string;
+  posts: SignalPost[];
+  narrative: string;
+  citations: string[];
+  generated_at: string;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    x_search_calls?: number;
+    cost_usd?: number;
+  };
+}
+
+interface XaiResponse {
+  output?: Array<{
+    type: string;
+    content?: Array<{
+      type: string;
+      text?: string;
+      annotations?: Array<{ type: string; url?: string }>;
+    }>;
+  }>;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cost_in_usd_ticks?: number;
+    server_side_tool_usage_details?: {
+      x_search_calls?: number;
+    };
+  };
+  error?: { message?: string } | string;
+}
+
+function extractTextAndCitations(
+  body: XaiResponse,
+): { text: string; citations: string[] } {
+  const messages = (body.output ?? []).filter((o) => o.type === "message");
+  const last = messages[messages.length - 1];
+  const blocks = last?.content ?? [];
+  const text = blocks
+    .filter((b) => b.type === "output_text")
+    .map((b) => b.text ?? "")
+    .join("\n")
+    .trim();
+  const citations: string[] = [];
+  for (const b of blocks) {
+    for (const a of b.annotations ?? []) {
+      if (a.type === "url_citation" && a.url) citations.push(a.url);
+    }
+  }
+  return { text, citations };
+}
+
+function tryParsePosts(text: string): SignalPost[] {
+  const stripped = text.replace(/^```json\s*/i, "").replace(/```\s*$/i, "").trim();
+  try {
+    const parsed = JSON.parse(stripped) as { posts?: SignalPost[] } | SignalPost[];
+    if (Array.isArray(parsed)) return parsed;
+    return parsed.posts ?? [];
+  } catch {
+    return [];
+  }
+}
+
+function buildPrompt(query: string, hoursBack: number): string {
+  return [
+    `Search X for the most-engaged posts in the last ${hoursBack} hours about: "${query}".`,
+    `Return ONLY a single JSON object with this exact shape — no prose, no markdown fences:`,
+    `{`,
+    `  "posts": [`,
+    `    {`,
+    `      "handle": "@username",`,
+    `      "text": "the post body verbatim",`,
+    `      "posted_at": "ISO timestamp if available",`,
+    `      "url": "https://x.com/...",`,
+    `      "retweets_estimate": 0,`,
+    `      "likes_estimate": 0`,
+    `    }`,
+    `  ],`,
+    `  "narrative": "one or two sentences summarizing the dominant story across these posts"`,
+    `}`,
+    `Return up to 10 posts, ranked by engagement. If no relevant posts found, return an empty posts array with a narrative explaining the absence.`,
+  ].join("\n");
+}
+
+export async function grokSearchX(
+  query: string,
+  hoursBack: number,
+  apiKey: string,
+): Promise<SignalResult> {
+  const res = await fetch(XAI_RESPONSES_URL, {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "grok-4.3",
+      input: [{ role: "user", content: buildPrompt(query, hoursBack) }],
+      tools: [{ type: "x_search" }],
+    }),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(`xai responses ${res.status}: ${detail.slice(0, 300)}`);
+  }
+  const body = (await res.json()) as XaiResponse;
+  if (body.error) {
+    const msg = typeof body.error === "string" ? body.error : body.error.message ?? "unknown error";
+    throw new Error(`xai error: ${msg}`);
+  }
+
+  const { text, citations } = extractTextAndCitations(body);
+  const posts = tryParsePosts(text);
+
+  let narrative = "";
+  try {
+    const obj = JSON.parse(text.replace(/^```json\s*/i, "").replace(/```\s*$/i, "").trim()) as {
+      narrative?: string;
+    };
+    narrative = obj.narrative ?? "";
+  } catch {
+    narrative = text.length < 500 ? text : `${text.slice(0, 500)}…`;
+  }
+
+  const usage = body.usage;
+  const costUsd = usage?.cost_in_usd_ticks
+    ? usage.cost_in_usd_ticks / 1_000_000_000
+    : undefined;
+
+  return {
+    query,
+    hours_back: hoursBack,
+    source: "x.com via xAI Responses API + x_search tool",
+    posts,
+    narrative,
+    citations,
+    generated_at: new Date().toISOString(),
+    usage: {
+      input_tokens: usage?.input_tokens,
+      output_tokens: usage?.output_tokens,
+      x_search_calls: usage?.server_side_tool_usage_details?.x_search_calls,
+      cost_usd: costUsd,
+    },
+  };
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -4,6 +4,7 @@ import { PolymarketAdapter } from "./adapters/polymarket.js";
 import { recommendFromUrl } from "./recommend.js";
 import { decorateMarket, decorateMarkets, type AffiliateConfig } from "./affiliate.js";
 import { decorateWithImages } from "./imagen.js";
+import { grokSearchX } from "./grok.js";
 import { HistoryRangeSchema } from "./schema.js";
 import type { NormalizedMarket } from "./schema.js";
 
@@ -21,6 +22,7 @@ interface ToolEnv {
   ANTHROPIC_API_KEY?: string;
   EXA_API_KEY?: string;
   OPENAI_API_KEY?: string;
+  XAI_API_KEY?: string;
   POLYMARKET_REF_CODE?: string;
   KALSHI_REF_CODE?: string;
   LIMITLESS_REF_CODE?: string;
@@ -82,6 +84,11 @@ export const HistoryInputSchema = z.object({
   range: HistoryRangeSchema.default("24h"),
 });
 
+export const SignalInputSchema = z.object({
+  query: z.string().min(2),
+  hours_back: z.union([z.literal(1), z.literal(6), z.literal(24), z.literal(72)]).default(24),
+});
+
 export const TOOL_DEFS = [
   {
     name: "pm_discover",
@@ -138,6 +145,27 @@ export const TOOL_DEFS = [
         },
       },
       required: ["market"],
+    },
+  },
+  {
+    name: "pm_signal",
+    description:
+      "Live X (Twitter) signal for a hypothesis or market topic, via Grok's first-party x_search. Returns the most-engaged recent posts with citations + a one-line narrative summary. Use this AFTER pm_history to answer 'why did this market just move?' — pm_history shows WHAT happened, pm_signal shows WHAT WAS BEING SAID. Polymarket / Kalshi / political / crypto markets all move on X chatter; this exposes that chatter directly. Latency 5-15s and cost ~$0.05/call so keep it opt-in, not in the hot path.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Topic, hypothesis, or market question. Free-form natural language. Examples: 'Russia Ukraine ceasefire', 'Polymarket MegaETH FDV market', 'Powell rate cut June'.",
+        },
+        hours_back: {
+          type: "number",
+          enum: [1, 6, 24, 72],
+          default: 24,
+          description: "Time window for the X search. Smaller windows surface fresher signal but may return fewer posts.",
+        },
+      },
+      required: ["query"],
     },
   },
   {
@@ -402,6 +430,17 @@ export async function runTool(name: string, args: unknown, env: ToolEnv = {}): P
     }
     const result = await adapter.getHistory(ref.id, range);
     if (!result) return err({ error: "market_not_found", venue: ref.venue, id: ref.id });
+    return ok(result);
+  }
+  if (name === "pm_signal") {
+    const { query, hours_back } = SignalInputSchema.parse(args);
+    if (!env.XAI_API_KEY) {
+      return err({
+        error: "xai_api_key_not_configured",
+        detail: "Set XAI_API_KEY via `wrangler secret put XAI_API_KEY` (production) or .dev.vars (local). Get a key at https://console.x.ai.",
+      });
+    }
+    const result = await grokSearchX(query, hours_back, env.XAI_API_KEY);
     return ok(result);
   }
   if (name === "pm_disputes_active") {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -27,6 +27,7 @@ interface WorkerEnv {
   FIRECRAWL_API_KEY?: string;
   ANTHROPIC_API_KEY?: string;
   EXA_API_KEY?: string;
+  XAI_API_KEY?: string;
   POLYMARKET_REF_CODE?: string;
   KALSHI_REF_CODE?: string;
   LIMITLESS_REF_CODE?: string;


### PR DESCRIPTION
Cherry-picks Marc's `pm_signal` from #19 onto current init. Marc's design (xAI Responses API + x_search agent tool, returns posts + narrative + citations) kept verbatim. Reconciliation: ToolResult ok/err wrapping (v0.1.7 pattern), `XAI_API_KEY` added to ToolEnv + WorkerEnv, SignalInputSchema after HistoryInputSchema, tool def position between pm_recommend and pm_disputes_active. Without XAI_API_KEY secret, pm_signal returns an err response pointing at the setup steps. Live on allbets.dev/mcp. Closes #19.