### PR TITLE
fix(v0.2.2): pm_signal + visual-mode end-to-end fixes

### DIFF
--- a/src/grok.ts
+++ b/src/grok.ts
@@ -12,7 +12,7 @@
 // reasoning — and only Grok provides the firehose.
 
 const XAI_RESPONSES_URL = "https://api.x.ai/v1/responses";
-const FETCH_TIMEOUT_MS = 30_000; // x_search internally makes multiple searches
+const FETCH_TIMEOUT_MS = 90_000; // x_search internally makes multiple searches; gpt-grok-style tool loop can be slow
 
 export interface SignalPost {
   handle?: string;
@@ -123,7 +123,7 @@ export async function grokSearchX(
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      model: "grok-4.3",
+      model: "grok-4-fast",
       input: [{ role: "user", content: buildPrompt(query, hoursBack) }],
       tools: [{ type: "x_search" }],
     }),

--- a/src/imagen.ts
+++ b/src/imagen.ts
@@ -7,9 +7,9 @@ export interface ImagenResult {
 }
 
 const OPENAI_BASE = "https://api.openai.com/v1";
-const MODEL = "gpt-image-1";
+const MODEL = "dall-e-3";
 const SIZE = "1024x1024";
-const TIMEOUT_MS = 25000;
+const TIMEOUT_MS = 90000;
 
 function buildPrompt(market: NormalizedMarket): string {
   const yesProb =
@@ -49,6 +49,7 @@ export async function generateMarketImage(
         prompt,
         n: 1,
         size: SIZE,
+        response_format: "url",
       }),
       signal: ctrl.signal,
     });
@@ -62,11 +63,19 @@ export async function generateMarketImage(
     const json = (await res.json()) as {
       data?: Array<{ url?: string; b64_json?: string }>;
     };
-    const url = json.data?.[0]?.url;
-    if (!url) {
-      return { image_prompt: prompt, warning: "openai response missing data[0].url" };
+    const datum = json.data?.[0];
+    if (datum?.url) return { image_url: datum.url, image_prompt: prompt };
+    if (datum?.b64_json) {
+      // fallback for image models that ignore response_format and always return b64
+      return {
+        image_url: `data:image/png;base64,${datum.b64_json}`,
+        image_prompt: prompt,
+      };
     }
-    return { image_url: url, image_prompt: prompt };
+    return {
+      image_prompt: prompt,
+      warning: "openai response missing data[0].url and data[0].b64_json",
+    };
   } catch (err) {
     return {
       image_prompt: prompt,


### PR DESCRIPTION
Three production-blocking fixes after live smoke-test on demo endpoint. Both pm_signal and pm_recommend visual:true now return data successfully through MCP.

**Fixes:**
1. **Image gen: gpt-image-1 → dall-e-3.** gpt-image-1 returns b64_json by default and ignores response_format='url'. dall-e-3 returns URL natively. Same $0.04/image. Added b64_json fallback for graceful future model swaps.
2. **Image timeout 25s → 90s.** Generation can take 15-40s; old ceiling caused 'operation aborted' warnings.
3. **Grok model grok-4.3 → grok-4-fast.** x_search makes multiple internal calls; grok-4.3 exceeded MCP client's 60s ceiling. grok-4-fast cuts that to ~10-15s with comparable summarization quality.

**Smoke-tested live:**
- `pm_signal('Anthropic Claude best AI model', 24h)` → posts/narrative/citations returned in ~10s, $0.057 cost
- `pm_recommend('https://scrollinondubs.substack.com/', visual: true)` → image_url populated on every recommended market

Live on allbets.dev/mcp.