### PR TITLE
fix: resolve PR #24/#25 conflict markers blocking deploy

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -85,17 +85,16 @@ export const HistoryInputSchema = z.object({
   range: HistoryRangeSchema.default("24h"),
 });
 
-<<<<<<< feat/v0.1.9-pm-ev
 export const EvInputSchema = z.object({
   market: z.string().min(1),
   p_yes: z.number().min(0).max(1).optional(),
   bankroll_usd: z.number().nonnegative().optional(),
   kelly_fraction: z.number().min(0).max(1).default(DEFAULT_KELLY_FRACTION),
-=======
+});
+
 export const SignalInputSchema = z.object({
   query: z.string().min(2),
   hours_back: z.union([z.literal(1), z.literal(6), z.literal(24), z.literal(72)]).default(24),
->>>>>>> init
 });
 
 export const TOOL_DEFS = [


### PR DESCRIPTION
## Why allbets.dev is stale

Marc's PR #24 (`pm_ev`) and PR #25 (`pm_signal` / v0.2.2) both added schemas at the same point in `src/tools.ts`. The auto-merge of `init` into Marc's branch left raw conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) in place, which got committed and merged into `init`. `wrangler deploy` fails with `Unexpected "<<"` at `src/tools.ts:88`, which is why the live landing page still shows `v0.1.1` / "Six tools" instead of `v0.1.9` / "Nine tools" with the pm_signal, pm_history, pm_ev sections Marc added.

## Fix

Keep both `EvInputSchema` and `SignalInputSchema` as separate exports — both are referenced downstream in this file. Verified clean with `wrangler deploy --dry-run` (Total Upload: 1499.61 KiB).

## Test plan
- [x] `wrangler deploy --dry-run` succeeds locally
- [ ] Sean merges this PR
- [ ] `wrangler deploy` from `init`
- [ ] Verify allbets.dev shows `v0.1.9`, "Nine tools", and the pm_signal/pm_history/pm_ev sections