### PR TITLE
feat(visual): thematic subject illustration via Workers AI (#27)

### DIFF
--- a/src/imagen.ts
+++ b/src/imagen.ts
@@ -3,7 +3,12 @@ import type { NormalizedMarket } from "./schema.js";
 export interface ImagenResult {
   image_url?: string;
   image_prompt?: string;
+  image_subject?: string;
   warning?: string;
+}
+
+interface WorkersAIBinding {
+  run(model: string, input: Record<string, unknown>): Promise<unknown>;
 }
 
 const OPENAI_BASE = "https://api.openai.com/v1";
@@ -11,30 +16,88 @@ const MODEL = "dall-e-3";
 const SIZE = "1024x1024";
 const TIMEOUT_MS = 90000;
 
-function buildPrompt(market: NormalizedMarket): string {
-  const yesProb =
-    market.outcomes.find((o) => /yes/i.test(o.label))?.probability ?? 0.5;
-  const yesPct = Math.round(yesProb * 100);
-  const ev = market.event_question ?? market.question;
-  const safeQ = market.question.replace(/["\\]/g, "");
+const SUBJECT_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast";
+const SUBJECT_TIMEOUT_MS = 8000;
+
+const SUBJECT_SYSTEM_PROMPT = `You translate prediction-market questions into a one-sentence visual subject for an editorial illustrator.
+
+Rules:
+- Output ONE sentence describing the concrete subject of the bet: people, places, objects, scenery, or activity.
+- NEVER mention prediction markets, betting, odds, probabilities, percentages, charts, tickets, UI, screens, dashboards, or numbers.
+- NEVER quote the question. NEVER include the words "yes" or "no".
+- Translate proper nouns into visual cues (e.g. "Jerome Powell" → "the Federal Reserve chairman at a press-conference podium"; "Bitcoin" → "stacks of golden coins on a dark trading desk").
+- Pick a single focal subject. Concrete, photographable, magazine-spread.
+- For sports: the sport itself + the teams/athletes. For politics: the politician + relevant setting. For finance: the institution or asset, never charts. For pop culture: the figure + their world.
+
+Output JSON: {"subject": "<one sentence>"}.`;
+
+function styleBlock(): string {
   return [
-    `Editorial illustration for a prediction market.`,
-    `Question: "${safeQ}".`,
-    ev !== market.question ? `Event context: "${ev.replace(/["\\]/g, "")}".` : "",
-    `Current market consensus: ${yesPct}% YES.`,
-    `Style: clean editorial illustration, muted palette, single focal subject, magazine-spread feel.`,
-    `Constraints: no text overlay, no charts, no logos, no UI screenshots, no AI-slop aesthetics, no purple gradients.`,
-    `Tone matches the question subject: serious for politics or finance, playful for sports or pop culture.`,
-  ]
-    .filter(Boolean)
-    .join(" ");
+    "Style: clean editorial illustration, muted palette, single focal subject, magazine-spread feel, painterly but restrained.",
+    "Constraints: no text, no captions, no numbers, no charts, no graphs, no logos, no UI, no screens, no tickets, no dashboards, no percentage signs, no AI-slop aesthetics, no purple gradients, no neon.",
+    "Tone matches subject: serious for politics or finance, playful for sports or pop culture, atmospheric for world events.",
+  ].join(" ");
+}
+
+function fallbackSubject(market: NormalizedMarket): string {
+  // No AI binding or extraction failed. Strip the question to a usable noun phrase.
+  const q = market.event_question ?? market.question;
+  const cleaned = q
+    .replace(/\?/g, "")
+    .replace(/^(will|does|is|are|can|should|did|has|have|do)\s+/i, "")
+    .replace(/\s+by\s+\d{4}.*$/i, "")
+    .replace(/\s+before\s+\d{4}.*$/i, "")
+    .replace(/\s+in\s+\d{4}.*$/i, "")
+    .trim();
+  return `A symbolic editorial scene depicting ${cleaned}.`;
+}
+
+async function extractSubject(
+  market: NormalizedMarket,
+  ai: WorkersAIBinding | undefined,
+): Promise<string> {
+  if (!ai) return fallbackSubject(market);
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), SUBJECT_TIMEOUT_MS);
+  try {
+    const ev = market.event_question ?? "";
+    const userMsg =
+      ev && ev !== market.question
+        ? `Question: ${market.question}\nEvent context: ${ev}`
+        : `Question: ${market.question}`;
+    const result = (await ai.run(SUBJECT_MODEL, {
+      messages: [
+        { role: "system", content: SUBJECT_SYSTEM_PROMPT },
+        { role: "user", content: userMsg },
+      ],
+      response_format: { type: "json_object" },
+      max_tokens: 200,
+      temperature: 0.4,
+    })) as { response?: string } | string;
+
+    const raw = typeof result === "string" ? result : result.response ?? "";
+    const parsed = JSON.parse(raw) as { subject?: unknown };
+    const subject = typeof parsed.subject === "string" ? parsed.subject.trim() : "";
+    if (!subject) return fallbackSubject(market);
+    return subject;
+  } catch {
+    return fallbackSubject(market);
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function buildPrompt(subject: string): string {
+  return `Editorial illustration. Subject: ${subject} ${styleBlock()}`;
 }
 
 export async function generateMarketImage(
   market: NormalizedMarket,
   apiKey: string,
+  ai: WorkersAIBinding | undefined,
 ): Promise<ImagenResult> {
-  const prompt = buildPrompt(market);
+  const subject = await extractSubject(market, ai);
+  const prompt = buildPrompt(subject);
   const ctrl = new AbortController();
   const t = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
   try {
@@ -57,6 +120,7 @@ export async function generateMarketImage(
       const body = await res.text();
       return {
         image_prompt: prompt,
+        image_subject: subject,
         warning: `openai images ${res.status}: ${body.slice(0, 200)}`,
       };
     }
@@ -64,21 +128,23 @@ export async function generateMarketImage(
       data?: Array<{ url?: string; b64_json?: string }>;
     };
     const datum = json.data?.[0];
-    if (datum?.url) return { image_url: datum.url, image_prompt: prompt };
+    if (datum?.url) return { image_url: datum.url, image_prompt: prompt, image_subject: subject };
     if (datum?.b64_json) {
-      // fallback for image models that ignore response_format and always return b64
       return {
         image_url: `data:image/png;base64,${datum.b64_json}`,
         image_prompt: prompt,
+        image_subject: subject,
       };
     }
     return {
       image_prompt: prompt,
+      image_subject: subject,
       warning: "openai response missing data[0].url and data[0].b64_json",
     };
   } catch (err) {
     return {
       image_prompt: prompt,
+      image_subject: subject,
       warning: `openai images failed: ${err instanceof Error ? err.message : String(err)}`,
     };
   } finally {
@@ -90,6 +156,7 @@ export async function decorateWithImages(
   markets: NormalizedMarket[],
   apiKey: string | undefined,
   enabled: boolean,
+  ai?: WorkersAIBinding,
 ): Promise<{ markets: NormalizedMarket[]; warnings: string[] }> {
   const warnings: string[] = [];
   if (!enabled) return { markets, warnings };
@@ -98,7 +165,7 @@ export async function decorateWithImages(
     return { markets, warnings };
   }
   const settled = await Promise.allSettled(
-    markets.map((m) => generateMarketImage(m, apiKey)),
+    markets.map((m) => generateMarketImage(m, apiKey, ai)),
   );
   const out = markets.map((m, i) => {
     const r = settled[i];
@@ -112,6 +179,7 @@ export async function decorateWithImages(
       ...m,
       image_url: r.value.image_url,
       image_prompt: r.value.image_prompt,
+      image_subject: r.value.image_subject,
     };
   });
   return { markets: out, warnings };

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -82,6 +82,7 @@ export const NormalizedMarketSchema = z.object({
   affiliate_disclosure: z.string().optional(),
   image_url: z.string().url().optional(),
   image_prompt: z.string().optional(),
+  image_subject: z.string().optional(),
   raw: z.unknown().optional(),
 });
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -359,7 +359,7 @@ export async function runTool(name: string, args: unknown, env: ToolEnv = {}): P
       decorated.per_venue.forEach((v) => {
         if (v.best_match) allMarkets.push(v.best_match);
       });
-      const { markets: withImages, warnings } = await decorateWithImages(allMarkets, env.OPENAI_API_KEY, true);
+      const { markets: withImages, warnings } = await decorateWithImages(allMarkets, env.OPENAI_API_KEY, true, env.AI);
       const imageByKey = new Map<string, NormalizedMarket>();
       withImages.forEach((m) => imageByKey.set(`${m.venue}:${m.venue_market_id}`, m));
       decorated = {
@@ -404,7 +404,7 @@ export async function runTool(name: string, args: unknown, env: ToolEnv = {}): P
     }
     if (visual) {
       const markets = result.recommendations.map((r) => r.market);
-      const { markets: withImages, warnings } = await decorateWithImages(markets, env.OPENAI_API_KEY, true);
+      const { markets: withImages, warnings } = await decorateWithImages(markets, env.OPENAI_API_KEY, true, env.AI);
       result = {
         ...result,
         recommendations: result.recommendations.map((rec, i) => ({
@@ -438,7 +438,7 @@ export async function runTool(name: string, args: unknown, env: ToolEnv = {}): P
     let decorated = decorateMarket(m, affiliateConfig);
     const warnings: string[] = [];
     if (visual) {
-      const result = await decorateWithImages([decorated], env.OPENAI_API_KEY, true);
+      const result = await decorateWithImages([decorated], env.OPENAI_API_KEY, true, env.AI);
       decorated = result.markets[0] ?? decorated;
       warnings.push(...result.warnings);
     }


### PR DESCRIPTION
Closes #27.

## Summary

- Visual mode now generates a thematic image of the bet's *subject* — people, places, objects, scenery — instead of a templated trade-screen.
- Root cause was the prompt itself: `src/imagen.ts` interpolated the literal question and the YES consensus percentage, which biased `dall-e-3` toward UI/ticket/chart aesthetics regardless of the negative constraints in the style block.
- New flow: each `market.question` runs through Workers AI (`@cf/meta/llama-3.3-70b-instruct-fp8-fast`, already bound at `env.AI`) to extract a one-sentence visual subject — concrete, photographable, no betting/odds vocabulary, no numbers, no quotes. The image model receives only the extracted subject plus the (hardened) editorial style block.

## Changes

- `src/imagen.ts` — new `extractSubject` step (8s timeout, falls back to a heuristic noun-phrase if `env.AI` is missing or the call fails). Style block expanded to explicitly ban screens, dashboards, percentage signs, and AI-slop neon. No literal question or consensus percentage anywhere in the prompt.
- `src/schema.ts` — adds `image_subject` to `NormalizedMarket` so callers can see what subject the model was asked to draw (debuggable).
- `src/tools.ts` — `pm_discover`, `pm_quote`, `pm_recommend` pass `env.AI` through to `decorateWithImages`.

Same toggle (`visual:true`), same response shape (`image_url`, `image_prompt`), one new optional field (`image_subject`).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `wrangler deploy --dry-run` clean (1502.22 KiB / gzip 289.34 KiB; was 1499.61 / 288.52 — +2.6 KiB upload)
- [ ] Sean merges
- [ ] Deploy to allbets.dev
- [ ] Run `pm_quote market="polymarket:<id>" visual=true` against a politics, sports, and finance market — verify the returned `image_url` shows the bet's subject (e.g. Powell at a podium for a rates market) and `image_subject` reads as a concrete scene description, not the original question