### PR TITLE
feat(landing): link contributor names in footer to their sites

### DIFF
--- a/src/landing.ts
+++ b/src/landing.ts
@@ -653,7 +653,7 @@ export const LANDING_HTML = `<!doctype html>
     </section>
 
     <footer>
-      <div>built at agents day lisbon · 2026-05-01 · marc johnson + sean tierney + jax</div>
+      <div>built at agents day lisbon · 2026-05-01 · <a href="https://marcjohnson.xyz" target="_blank" rel="noopener">marc johnson</a> + <a href="https://scrollinondubs.com" target="_blank" rel="noopener">sean tierney</a> + <a href="https://behalf.bot" target="_blank" rel="noopener">jax</a></div>
       <div>
         <a href="https://github.com/scrollinondubs/allbets" target="_blank" rel="noopener">github</a>
         &nbsp;·&nbsp;


### PR DESCRIPTION
## Summary

Sean asked: link the three contributor names in the AllBets.dev landing-page footer to their respective sites.

- Marc Johnson → https://marcjohnson.xyz
- Sean Tierney → https://scrollinondubs.com
- Jax → https://behalf.bot

Single-line change in `src/landing.ts` line 656 — the static landing template baked into the Worker bundle.

## Test plan

- [ ] After merge + Cloudflare Worker deploy, visit https://allbets.dev — footer reads `built at agents day lisbon · 2026-05-01 · [marc johnson] + [sean tierney] + [jax]` with the three names rendered as `border-bottom: 1px dotted` links per existing footer style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)